### PR TITLE
Clean up temp files after upload completes or fails

### DIFF
--- a/app.py
+++ b/app.py
@@ -85,13 +85,18 @@ def upload():
         # Authenticate Session
         ses = authenticated_session()
 
-        # Check whether we have enough data or not
-        if None not in (downloaded_filename, tr_filename, src_fileext, ses):
-            file_path = 'temp_images/' + downloaded_filename
-            file_size = os.path.getsize(file_path)
+        # If the file was downloaded but other required data is missing, clean up before returning
+        if None in (downloaded_filename, tr_filename, src_fileext, ses):
+            if downloaded_filename:
+                _delete_temp_file(os.path.join('temp_images', downloaded_filename))
+            return jsonify({"success": False, "data": {}, "errors": ["Not enough data"]}), 400
 
-            if file_size < 50 * 1024 * 1024:  # 50 MB
-                # Process synchronously
+        file_path = os.path.join('temp_images', downloaded_filename)
+        file_size = os.path.getsize(file_path)
+
+        if file_size < 50 * 1024 * 1024:  # 50 MB
+            # Process synchronously — clean up temp file when done regardless of outcome
+            try:
                 resp = process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses)
                 if resp is None:
                     return jsonify({"success": False, "data": {}, "errors": ["Upload failed"]}), 500
@@ -103,18 +108,18 @@ def upload():
                     "data": resp,
                     "errors": []
                 }), 200
-            else:
-                # Process asynchronously using Celery
-                OAuthObj = {
-                    "consumer_key": CONSUMER_KEY,
-                    "consumer_secret": CONSUMER_SECRET,
-                    "key": session['mwoauth_access_token']['key'],
-                    "secret": session['mwoauth_access_token']['secret']
-                }
-                task = upload_image_task.delay(file_path, tr_filename, src_fileext, tr_endpoint, OAuthObj)
-                return jsonify({"success": True, "task_id": task.id}), 202
+            finally:
+                _delete_temp_file(file_path)
         else:
-            return jsonify({"success": False, "data": {}, "errors": ["Not enough data"]}), 400
+            # Process asynchronously — the Celery task is responsible for cleaning up the file
+            OAuthObj = {
+                "consumer_key": CONSUMER_KEY,
+                "consumer_secret": CONSUMER_SECRET,
+                "key": session['mwoauth_access_token']['key'],
+                "secret": session['mwoauth_access_token']['secret']
+            }
+            task = upload_image_task.delay(file_path, tr_filename, src_fileext, tr_endpoint, OAuthObj)
+            return jsonify({"success": True, "task_id": task.id}), 202
     else:
         return jsonify({"success": False, "data": {}, "errors": ["Invalid Request"]}), 400
 
@@ -334,6 +339,13 @@ def get_task_status(task_id):
         response["error"] = str(task.result)
 
     return jsonify(response), 200
+
+
+def _delete_temp_file(file_path):
+    try:
+        os.remove(file_path)
+    except OSError as e:
+        logger.warning("Could not remove temp file %s: %s", file_path, e)
 
 
 def authenticated_session():

--- a/tasks.py
+++ b/tasks.py
@@ -1,7 +1,11 @@
-from celeryWorker import app
+import os
+import logging
 import requests
 import requests_oauthlib
-import os
+from celeryWorker import app
+
+logger = logging.getLogger(__name__)
+
 
 @app.task(bind=True)
 def upload_image_task(self, file_path, tr_filename, src_fileext, tr_endpoint, OAuthObj):
@@ -12,7 +16,7 @@ def upload_image_task(self, file_path, tr_filename, src_fileext, tr_endpoint, OA
         resource_owner_secret=OAuthObj["secret"]
     )
     self.update_state(state='PROGRESS', meta={'current': 0, 'total': 100})
-    
+
     # API Parameter to get CSRF Token
     csrf_param = {
         "action": "query",
@@ -20,39 +24,47 @@ def upload_image_task(self, file_path, tr_filename, src_fileext, tr_endpoint, OA
         "format": "json"
     }
 
-    response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses)
-    csrf_token = response.json()["query"]["tokens"]["csrftoken"]
-
-    self.update_state(state='PROGRESS', meta={'current': 25, 'total': 100})
-
-    # API Parameter to upload the file
-    upload_param = {
-        "action": "upload",
-        "filename": tr_filename + "." + src_fileext,
-        "format": "json",
-        "token": csrf_token,
-        "ignorewarnings": 1
-    }
-
-    # Read the file for POST request
-    file = {
-        'file': open(file_path, 'rb')
-    }
-
-    response = requests.post(url=tr_endpoint, files=file, data=upload_param, auth=ses).json()
-
-    self.update_state(state='PROGRESS', meta={'current': 75, 'total': 100})
-
-    # Try block to get Link and URL
     try:
-        wikifile_url = response["upload"]["imageinfo"]["descriptionurl"]
-        file_link = response["upload"]["imageinfo"]["url"]
-    except KeyError:
-        return {"success": False, "data": {}, "errors": ["Upload failed"]}
+        response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses)
+        csrf_token = response.json()["query"]["tokens"]["csrftoken"]
 
-    self.update_state(state='PROGRESS', meta={'current': 100, 'total': 100})
+        self.update_state(state='PROGRESS', meta={'current': 25, 'total': 100})
 
-    return {
-        "wikipage_url": wikifile_url,
-        "file_link": file_link
-    }
+        # API Parameter to upload the file
+        upload_param = {
+            "action": "upload",
+            "filename": tr_filename + "." + src_fileext,
+            "format": "json",
+            "token": csrf_token,
+            "ignorewarnings": 1
+        }
+
+        # Read the file for POST request
+        file = {
+            'file': open(file_path, 'rb')
+        }
+
+        response = requests.post(url=tr_endpoint, files=file, data=upload_param, auth=ses).json()
+
+        self.update_state(state='PROGRESS', meta={'current': 75, 'total': 100})
+
+        # Try block to get Link and URL
+        try:
+            wikifile_url = response["upload"]["imageinfo"]["descriptionurl"]
+            file_link = response["upload"]["imageinfo"]["url"]
+        except KeyError:
+            return {"success": False, "data": {}, "errors": ["Upload failed"]}
+
+        self.update_state(state='PROGRESS', meta={'current': 100, 'total': 100})
+
+        return {
+            "wikipage_url": wikifile_url,
+            "file_link": file_link
+        }
+
+    finally:
+        # Always remove the temp file once the task finishes, success or failure
+        try:
+            os.remove(file_path)
+        except OSError as e:
+            logger.warning("Could not remove temp file %s: %s", file_path, e)


### PR DESCRIPTION
 ## Fix: temp files in temp_images/ are never cleaned up (T415717)                                                                     
  Closes T415717 (https://phabricator.wikimedia.org/T415717)                                                                                                                                                                                                              
  ### Problem                                                                                                                                                                                                                                                             
  Every file transfer downloads a temp file into `temp_images/` but
  nothing ever deletes it. In production this means the directory grows
  indefinitely — every upload, successful or not, leaves a file behind.

  Three scenarios where files were leaking:

  1. **Sync uploads (<50MB)** — file downloaded, uploaded, returned —
     no cleanup at any point
  2. **Async uploads (≥50MB)** — Celery task uploads the file but never
     deletes it after finishing
  3. **Early exit** — if the session or target filename is missing after
     the file is already downloaded, it just stays there

  ### Fix

  - Wrapped the sync upload path in `try/finally` in `app.py` so the
    temp file is always deleted after `process_upload()` returns,
    whether it succeeded or raised
  - Added a `finally` block in the Celery task in `tasks.py` so async
    uploads clean up after themselves
  - Added an explicit cleanup before the early-exit return when required
    data is missing but a file was already downloaded

  ### Related

  - PR #44 — error handling improvements
  - T415562 — GSoC 2026 parent task




  Note: I submitted this PR before seeing the March 16 guideline posted
  to T415562. Happy to hold off on further patches until the contribution
  period opens — just wanted to flag the issues I found while reading the
  codebase. Let me know if you'd prefer I reopen after March 16.