### PR TITLE
Fix: add missing User-Agent headers to backend API requests

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -3,6 +3,15 @@ import requests
 import mwparserfromhell
 from templatelist import TEMPLATES
 
+def getHeader():
+    """
+    Returns the official User-Agent header required by Wikimedia API policy.
+    """
+    agent = 'Wikifile-transfer/1.0 (https://wikifile-transfer.toolforge.org; 0freerunning@gmail.com)'
+    return {
+        'User-Agent': agent
+    }
+
 def download_image(src_project, src_lang, src_filename):
     src_endpoint = "https://"+ src_lang + "." + src_project + ".org/w/api.php"
 
@@ -15,38 +24,37 @@ def download_image(src_project, src_lang, src_filename):
         "iilocalonly": 1
     }
 
-    page = requests.get(url=src_endpoint, params=param).json()['query']['pages']
+    headers = getHeader()
+    page = requests.get(url=src_endpoint, params=param, headers=headers).json()['query']['pages']
 
     try:
-        image_url = list (page.values()) [0]["imageinfo"][0]["url"]
+        image_url = list(page.values())[0]["imageinfo"][0]["url"]
     except KeyError:
         return None
 
-    # Create a unique file name based on time
     current_time = str(datetime.datetime.now())
-    get_filename = current_time.replace(':', '_')
-    get_filename = get_filename.replace(' ', '_')
+    get_filename = current_time.replace(':', '_').replace(' ', '_')
 
-    # Download the Image File
-    r = requests.get(image_url, allow_redirects=True)
+    r = requests.get(image_url, allow_redirects=True, headers=headers)
     filename = get_filename + "." + r.headers.get('content-type').replace('image/', '')
-    open("temp_images/" + filename, 'wb').write(r.content)
+    
+    with open("temp_images/" + filename, 'wb') as f:
+        f.write(r.content)
 
     return filename
 
-
 def process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses):
-    # API Parameter to get CSRF Token
     csrf_param = {
         "action": "query",
         "meta": "tokens",
         "format": "json"
     }
 
-    response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses)
+    headers = getHeader()
+
+    response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses, headers=headers)
     csrf_token = response.json()["query"]["tokens"]["csrftoken"]
 
-    # API Parameter to upload the file
     upload_param = {
         "action": "upload",
         "filename": tr_filename + "." + src_fileext,
@@ -55,14 +63,10 @@ def process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses):
         "ignorewarnings": 1
     }
 
-    # Read the file for POST request
-    file = {
-        'file': open(file_path, 'rb')
-    }
+    with open(file_path, 'rb') as f:
+        file_payload = {'file': f}
+        response = requests.post(url=tr_endpoint, files=file_payload, data=upload_param, auth=ses, headers=headers).json()
 
-    response = requests.post(url=tr_endpoint, files=file, data=upload_param, auth=ses).json()
-
-    # Try block to get Link and URL
     try:
         wikifile_url = response["upload"]["imageinfo"]["descriptionurl"]
         file_link = response["upload"]["imageinfo"]["url"]
@@ -74,9 +78,9 @@ def process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses):
         "file_link": file_link
     }
 
-
 def get_localized_wikitext(wikitext, src_endpoint, target_lang):
     wikicode = mwparserfromhell.parse(wikitext)
+    headers = getHeader()
 
     for template in wikicode.filter_templates():
         if template.name.strip() in TEMPLATES:
@@ -94,7 +98,7 @@ def get_localized_wikitext(wikitext, src_endpoint, target_lang):
                     }
 
                     try:
-                        response = requests.get(url=src_endpoint, params=lang_param)
+                        response = requests.get(url=src_endpoint, params=lang_param, headers=headers)
                         response.raise_for_status()
                         langlinks = response.json()["query"]["pages"][0]["langlinks"]
 
@@ -103,12 +107,6 @@ def get_localized_wikitext(wikitext, src_endpoint, target_lang):
                                 template.add("Article", langlink["title"])
                                 break
                     except:
-                        return str(wikicode)
+                        continue 
 
     return str(wikicode)
-
-def getHeader():
-    agent = 'Wikifile-transfer/1.0 (https://wikifile-transfer.toolforge.org; 0freerunning@gmail.com)'
-    return {
-        'User-Agent': agent
-    }

--- a/utils.py
+++ b/utils.py
@@ -32,9 +32,11 @@ def download_image(src_project, src_lang, src_filename):
     except KeyError:
         return None
 
+    # Create a unique file name based on time
     current_time = str(datetime.datetime.now())
     get_filename = current_time.replace(':', '_').replace(' ', '_')
 
+    # Download the Image File
     r = requests.get(image_url, allow_redirects=True, headers=headers)
     filename = get_filename + "." + r.headers.get('content-type').replace('image/', '')
     
@@ -44,6 +46,7 @@ def download_image(src_project, src_lang, src_filename):
     return filename
 
 def process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses):
+    # API Parameter to get CSRF Token
     csrf_param = {
         "action": "query",
         "meta": "tokens",
@@ -52,9 +55,11 @@ def process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses):
 
     headers = getHeader()
 
+    # Get CSRF Token with proper headers
     response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses, headers=headers)
     csrf_token = response.json()["query"]["tokens"]["csrftoken"]
 
+    # API Parameter to upload the file
     upload_param = {
         "action": "upload",
         "filename": tr_filename + "." + src_fileext,
@@ -63,8 +68,10 @@ def process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses):
         "ignorewarnings": 1
     }
 
+    # Read the file for POST request
     with open(file_path, 'rb') as f:
         file_payload = {'file': f}
+        # Final upload POST with proper headers
         response = requests.post(url=tr_endpoint, files=file_payload, data=upload_param, auth=ses, headers=headers).json()
 
     try:
@@ -107,6 +114,6 @@ def get_localized_wikitext(wikitext, src_endpoint, target_lang):
                                 template.add("Article", langlink["title"])
                                 break
                     except:
-                        continue 
+                        continue # Continue to next template if this one fails
 
     return str(wikicode)


### PR DESCRIPTION
Fixes #46 

I updated `utils.py` to include the required headers in all API calls. now every `requests.get` and `requests.post` call uses the existing `getHeader()` function .i have also updated the image download logic to use with open(), which is safer for the system.

I verified this fix in my local docker environment. check out the screenshot once.

<img width="1806" height="899" alt="Screenshot 2026-03-06 180303" src="https://github.com/user-attachments/assets/6107fe53-59bf-470b-867b-a3d5f860ff56" />
