### PR TITLE
Temp file cleanup t415717 backend

### DIFF
--- a/ERROR_HANDLING.md
+++ b/ERROR_HANDLING.md
@@ -1,0 +1,478 @@
+# Error Handling & Exception Architecture
+
+**Task:** T415715 | **Branch:** `Error_Handling_T415715_backend`
+
+---
+
+## Overview
+
+So... the backend had a real problem. Bare `except:` blocks everywhere, routes returning completely different shaped responses depending on who wrote them, and async task failures that just disappeared into thin air. No log entry, no error to the client, nothing. You'd get a broken response and spend an hour figuring out why.
+
+This PR fixes that. Five things changed:
+
+1. Custom exception hierarchy — so you know *what* failed, not just "something went wrong"
+2. Structured rotating log files — so failures are actually recorded and searchable
+3. Every bare `except:` replaced with typed catches and proper `raise X from e` chaining
+4. Every API endpoint returns the same JSON shape whether it succeeds or fails
+5. Celery task errors are captured, logged, and returned instead of silently vanishing
+
+No new dependencies. Everything uses Python's built-in `logging` module.
+
+---
+
+## Background — what the code looked like before
+
+Here's roughly what error handling looked like before this:
+
+```python
+try:
+    result = do_the_thing()
+except:  # catches EVERYTHING, including KeyboardInterrupt
+    return None  # good luck figuring out what happened
+```
+
+Routes returned different things on failure. Some returned `{"error": "..."}`, some returned `{"success": False}`, some just returned `None` and let the caller figure it out. The frontend was essentially guessing what shape it was going to get.
+
+The deeper problem was the silent failures. A download would fail, `None` would bubble up through the call stack, and the route would keep running as if everything was fine. No log entry, no error to the client, just a broken response that looked like a success. That's the kind of bug that shows up in production and takes way too long to track down.
+
+---
+
+## Files added / changed
+
+| File | What happened |
+|---|---|
+| `exceptions.py` | New — custom exception hierarchy |
+| `error_handlers.py` | New — Flask handler registration and JSON response builders |
+| `logging_config.py` | New — structured rotating log files, helper functions |
+| `utils.py` | Bare `except` blocks → typed catches with `raise X from e` chaining |
+| `app.py` | Routes now raise exceptions; `register_error_handlers()` wired at startup |
+| `tasks.py` | Per-step error handling, retry logic, structured logging, Celery `Retry` re-raise guard |
+| `tests/utils_test.py` | New — mocked unit tests for all three util functions |
+| `tests/tasks_test.py` | New — mocked unit tests for the async upload task with retry logic |
+| `tests/app_test.py` | New — Flask test client integration tests for every route in the app |
+
+---
+
+## Configuration
+
+**No new dependencies** — `pip install -r requirements.txt` is all you need.
+
+**Log directory** — `logs/` is created automatically the first time the app starts. You don't need to create it manually. If you want logs written somewhere else:
+
+```python
+setup_logging(log_dir="/your/path")
+```
+
+**Environment flag** — the only thing that changes between dev and production:
+
+```python
+setup_logging()           # production — log files only, no console noise
+setup_logging(env="dev")  # development — log files + console output
+```
+
+Called once in `app.py` at startup. In dev it's useful to see logs in the terminal without opening a file. In production, don't spam stdout.
+
+The three log files written to `logs/`:
+
+```
+wikifile-transfer.log              # human-readable, INFO and above
+wikifile-transfer-error.log        # ERROR and CRITICAL only — for quick scans
+wikifile-transfer-structured.jsonl # same events as JSON, one object per line
+```
+
+All three rotate at 10MB and keep 5 backups. The `.jsonl` file is mainly useful if you're piping logs into a log aggregator — each line is a valid JSON object you can parse directly.
+
+> Pro tip: run `tail -f logs/wikifile-transfer.log` in a separate terminal while testing. You'll see everything happening in real time instead of digging through the file.
+
+---
+
+## How it's structured
+
+Four files, each doing exactly one thing:
+
+```
+exceptions.py      → defines what can go wrong  (domain vocabulary)
+error_handlers.py  → decides what the client sees  (HTTP responses)
+logging_config.py  → decides what gets recorded  (log files)
+utils/app/tasks.py → where things actually fail  (raises the exceptions)
+```
+
+The separation is intentional. If you want to change `WikiAPIError` from 502 to 503, you change one line in `error_handlers.py`. You don't touch any of the `utils.py` code where that exception is raised. That's the whole point — presentation and business logic don't mix.
+
+---
+
+## exceptions.py — naming what went wrong
+
+Everything inherits from `WikifileTransferError`. The base class stores three things: a human-readable `message`, a machine-readable `error_code` string, and a `details` dict for any extra context.
+
+```
+WikifileTransferError (base)
+│
+├── ValidationError         — bad user input (missing fields, wrong URL format)
+├── WikiAPIError            — MediaWiki API failures (timeouts, bad status codes, unexpected response shape)
+├── FileOperationError      — download, write, or read failures on disk
+├── DatabaseError           — SQLAlchemy commit failures
+├── OAuthError              — token exists but is broken or rejected by the wiki
+├── AuthenticationError     — user has no session at all
+├── UploadError             — wiki accepted the request but rejected the upload
+├── ConfigurationError      — missing or broken config.yaml entries
+├── TaskError               — Celery async task-level failures
+└── ResourceNotFoundError   — image or file doesn't exist on the source wiki
+```
+
+Each subclass takes specific keyword arguments that get stored in `details`. `WikiAPIError` takes `api_endpoint` and `status_code`. `FileOperationError` takes `operation` and `file_path`. That context travels with the exception from where it's raised, through the handler, all the way into the log entry and client response. Which means when something breaks, you actually know where and why — not just "an error occurred."
+
+**Why not just use  HTTPException directly?**
+
+Because `WikiAPIError` is a domain concept, not an HTTP concept. It means "the MediaWiki API did something unexpected." That it maps to 502 is the *handler's* decision, not the exception's. If those concerns are mixed, every status code change means digging through business logic to find where exceptions are raised. Not worth it.
+
+---
+
+## error_handlers.py — what the client sees
+
+`register_error_handlers(app)` is called once at startup in `app.py`. It wires each exception class to a handler using Flask's `app.register_error_handler()`. When a route raises `WikiAPIError(...)`, Flask intercepts it before anything reaches the client and calls the right handler automatically.
+
+Every response — success or failure — has the same outer shape:
+
+```json
+{
+  "success": false,
+  "data": {},
+  "errors": ["Timeout while fetching image info"],
+  "error_details": {
+    "code": "WIKI_API_ERROR",
+    "message": "Timeout while fetching image info",
+    "details": { "api_endpoint": "https://en.wikipedia.org/w/api.php" }
+  }
+}
+```
+
+`success` is always boolean. `errors` is always a list. `error_details.code` is always one of the strings defined in `exceptions.py`. The frontend never has to guess what shape it's getting.
+
+**HTTP status codes:**
+
+| Exception | Status | Why |
+|---|---|---|
+| `ValidationError` | 400 | client sent something wrong |
+| `AuthenticationError` | 401 | no session at all |
+| `OAuthError` | 401 | session exists but token is broken |
+| `ResourceNotFoundError` | 404 | image doesn't exist on source wiki |
+| `WikiAPIError` | 502 | upstream wiki API failed — bad gateway |
+| `FileOperationError` | 500 | server-side disk failure |
+| `DatabaseError` | 500 | internal — real message hidden from client |
+| `ConfigurationError` | 500 | internal — real message hidden from client |
+| `UploadError` | 500 | wiki rejected the upload |
+| `TaskError` | 500 | async task failed |
+| `Exception` (catch-all) | 500 | anything we didn't anticipate |
+
+`DatabaseError` and `ConfigurationError` intentionally show the client a generic message ("please contact the administrator") instead of the real one. You really don't want internal database operation names or config key values leaking to users. The actual message still goes to the logs where it's useful.
+
+---
+
+## logging_config.py — structured logging
+
+**Helper functions used throughout the app:**
+
+`log_exception(logger, e, extra_context={})` — logs the full stack trace plus any extra context you pass. Use this when you're catching something and want the traceback recorded before re-raising.
+
+`log_timed_api_call(logger, endpoint, method)` — context manager that wraps any HTTP call and records how long it took, the status code, and whether it threw. Every `requests.get()` and `requests.post()` in `utils.py` and `tasks.py` is wrapped in this:
+
+```python
+with log_timed_api_call(logger, src_endpoint, "GET") as context:
+    response = requests.get(...)
+    context["status_code"] = response.status_code
+    # setting status_code here tells the context manager what to log
+    # it reads it in the else block after the with exits cleanly
+```
+
+`log_file_operation(logger, operation, file_path, success, error)` — records download, upload, and write events with the outcome. Gives you a paper trail of every file the app touched.
+
+`log_task_event(logger, task_id, task_name, status, error, progress)` — logs Celery task lifecycle events with the task ID on every line. Without the task ID attached, tracing a single async task through multiple log entries is really painful.
+
+---
+
+## Exception chaining — `raise X from e`
+
+This is the most important pattern in `utils.py`. Every time a low-level exception is caught and re-raised as a domain exception, it uses `from e`:
+
+```python
+except requests.exceptions.Timeout as e:
+    raise WikiAPIError(
+        f"Timeout while fetching image info for {src_filename}",
+        api_endpoint=src_endpoint,
+        details={"timeout_seconds": 30}
+    ) from e
+```
+
+The `from e` sets `__cause__` on the new exception. Without it, the original `requests.Timeout` disappears from the traceback — you only see the `WikiAPIError`. With it, you see both: the domain-level failure *and* the underlying cause that triggered it.
+
+When you're debugging a production failure, you need both. "The wiki API timed out" is useful. "The wiki API timed out because of *this specific connection error*" is actually actionable.
+
+---
+
+## utils.py — two-phase handling and per-article resilience
+
+`download_image()` has two separate try/except blocks instead of one combined one. The first covers fetching image metadata from the API. The second covers downloading the actual file bytes.
+
+This was deliberate. One big block would raise the same exception whether the image wasn't found on the wiki, or whether it was found but the download failed halfway. Those are different failures with different causes and they get different exceptions and different messages — `ResourceNotFoundError` vs `FileOperationError`.
+
+`get_localized_wikitext()` takes a completely different approach. Each per-article langlink lookup is wrapped individually inside the loop, and failures just log a warning and `continue`. If the Wikipedia API is flaky for one article title, that one gets skipped — the rest of the templates still get processed. The function never throws. The outer `except Exception` at the very end is a safety net that returns the original unmodified wikitext if something goes badly wrong with the parser itself. Better to return something than to crash the whole request.
+
+---
+
+## app.py — routes raise, handlers respond
+
+Routes don't build error responses anymore. They raise typed exceptions and let the registered handlers deal with them:
+
+```python
+ses = authenticated_session()
+if ses is None:
+    raise AuthenticationError("You must be logged in to upload files")
+```
+
+Flask catches the `AuthenticationError`, finds the registered handler, returns the 401 JSON response. The route code never calls `jsonify` for errors — it only cares about the happy path.
+
+`register_error_handlers(app)` runs once at startup. That's the only place exception classes are connected to handler functions.
+
+---
+
+## tasks.py — async tasks never raise, always return
+
+Celery tasks run outside the Flask request context, so Flask's error handlers don't apply here. The approach is different: **tasks catch everything and always return a dict.**
+
+```python
+return {"success": False, "data": {}, "errors": [error_msg]}
+# or on success:
+return {"success": True, "wikipage_url": ..., "file_link": ...}
+```
+
+The frontend polls `/api/task_status/<task_id>` and reads `result.success`. No exception propagation — the task absorbs failures and encodes the outcome in the return value.
+
+One thing that tripped me up: Celery's own `Retry` exception **must** be re-raised, not caught. If you swallow it and return a dict, Celery thinks the task completed successfully and stops retrying entirely. The `except Retry: raise` block at the bottom of the task is there specifically for this — don't remove it.
+
+Network timeouts trigger `self.retry(exc=e)` when retries remain (max 3, 60s delay). `AuthenticationError` skips the retry entirely — there's no point retrying with an expired OAuth token, it'll fail the same way every single time.
+
+---
+
+## OAuthError vs AuthenticationError
+
+These two look similar but they're describing completely different situations, and getting them confused leads to the wrong error message reaching the user.
+
+**`AuthenticationError`** — the user simply isn't logged in. Either they never went through the OAuth flow, or their session cookie expired and got cleared. The fix is: log in again. Nothing is broken, the session just doesn't exist.
+
+**`OAuthError`** — the user *did* log in. The token exists in the session. But when that token is sent to the wiki, the wiki rejects it. This happens when the consumer application gets deregistered on the wiki side, or when a token is manually revoked. The session cookie looks valid on our end, but the wiki won't accept it. Both return 401, but the underlying cause is totally different.
+
+There's also a third case that's easy to miss entirely — the `+\` CSRF token check in `process_upload()`:
+
+```python
+csrf_token = response.json()["query"]["tokens"]["csrftoken"]
+
+if csrf_token == "+\\":
+    raise AuthenticationError("Invalid CSRF token — OAuth session may have expired")
+```
+
+`+\` is the literal string MediaWiki returns for a CSRF token when it doesn't recognize the OAuth session. The HTTP response is still 200. No error code, no exception from `requests`, nothing to catch automatically. It's a semantic failure hidden inside a perfectly valid HTTP response — if you don't check for it explicitly, the upload proceeds with that bad token and fails later in a confusing way with no clear error. The explicit check catches it before it gets that far.
+
+In short:
+- No session at all → `AuthenticationError`
+- Session exists, wiki rejects the token → `OAuthError`
+- Session exists, wiki returns `+\` CSRF token → `AuthenticationError` (OAuth session isn't being recognized)
+
+---
+
+## Testing
+
+Three test files. Each one covers a different layer of the stack, and each one is completely offline — no Wikipedia, no Redis, no MySQL, no actual network traffic of any kind. The test suite should run just as happily on a plane with no Wi-Fi as it does in CI. (Tested. It does.)
+
+**Run everything at once:**
+
+```bash
+pytest tests/ -v
+```
+
+**Or target a specific file:**
+
+```bash
+pytest tests/utils_test.py -v    # utility functions
+pytest tests/tasks_test.py -v    # async Celery task
+pytest tests/app_test.py -v      # Flask routes end to end
+```
+
+---
+
+### tests/utils_test.py — the utility layer
+
+This is where the low-level networking lives: fetching image metadata, downloading the file, uploading to the target wiki, and localizing wikitext templates. All three functions in `utils.py` are covered here.
+
+`download_image()`:
+- Happy path returns a filename string with the correct extension
+- Metadata timeout → `WikiAPIError`, not `None`, not a generic `Exception`
+- Image download timeout → `FileOperationError` (different exception, different phase — the test actually verifies they're different types, not just that something was raised)
+- File missing on source wiki → `ResourceNotFoundError`
+- Disk write failure → `FileOperationError`
+- `iilocalonly` param is confirmed to be sent in the request (this matters — it's why Commons-hosted files sometimes return no imageinfo, and knowing it's intentionally there vs accidentally there is worth having in writing)
+
+`process_upload()`:
+- CSRF token `"+\\"` → `AuthenticationError`, caught before the upload even starts
+- CSRF request timeout → `WikiAPIError`
+- Missing keys in CSRF response → `WikiAPIError`
+- File missing before upload → `FileOperationError`
+- `OSError` reading the file → `FileOperationError`
+- Upload result `!= "Success"` → `WikiAPIError` with the wiki's own error message included in the exception
+- Upload says Success but no `imageinfo` in the response → `WikiAPIError` (MediaWiki says "it worked" but gives you nothing useful — that's a failure, treat it as one)
+
+`get_localized_wikitext()`:
+- Per-article timeout → skipped with a warning, processing continues for the remaining templates
+- Per-article request error → same — one article failing doesn't abort everything else
+- Parser crash → original wikitext returned unchanged, nothing raised
+- Template not in `TEMPLATES` → no API call made, ignored silently
+
+---
+
+### tests/tasks_test.py — the async task layer
+
+Celery tasks have a different failure model than Flask routes. They can't raise to the client. They can't use Flask error handlers. And they have retry logic on top of all that, which means the same network error can either trigger a retry or return a failure dict depending on how many attempts have already happened.
+
+The mock used here is worth knowing about. Every test gets a fake "Celery self" object that has `self.request.id`, `self.request.retries`, `self.max_retries`, and a `self.retry()` that raises `celery.exceptions.Retry` exactly like the real one does. This lets tests verify retry behavior without Celery running at all.
+
+`upload_image_task()`:
+- Happy path returns `{"success": True}` with correct `wikipage_url` and `file_link`
+- CSRF token from the GET request appears in the upload POST — verifies the token is actually being threaded through
+- Missing OAuth credentials → immediate failure dict, no network calls
+- Single missing OAuth key → failure dict with the key name in the error message
+- OAuth session creation failure → failure dict with helpful message
+- Anonymous CSRF token `"+\\"` → failure dict, **no retry** (retrying with a dead token is a waste of everyone's time)
+- CSRF timeout with retries remaining → raises `Retry` (Celery picks this up and reschedules)
+- CSRF timeout with retries exhausted → failure dict with "Timeout" in the error
+- CSRF network error → triggers retry
+- CSRF response missing expected keys → failure dict, no retry (this is a logic error, not a transient failure — retrying won't fix a broken response)
+- File not found on disk → failure dict
+- `OSError` reading file → failure dict
+- Upload timeout with retries remaining → raises `Retry`
+- Upload timeout with retries exhausted → failure dict
+- Upload network error → triggers retry
+- Upload result is `"Failure"` → failure dict with the wiki's own error message
+- Upload succeeds but `imageinfo` is missing → failure dict
+
+---
+
+### tests/app_test.py — the Flask route layer
+
+This one is a bit more involved because it's testing the actual HTTP layer — request parsing, route logic, error handler wiring, database reads and writes, the works. It uses Flask's test client with an in-memory SQLite database so no MySQL server is needed.
+
+**The one interesting setup trick:** `flask_mwoauth` is stubbed in `sys.modules` before `app.py` is imported. This replaces the real `MWOAuth` object with a `MagicMock`, which means tests can control `MW_OAUTH.get_current_user.return_value` directly without needing a real OAuth session. The blueprint it registers is a real Flask `Blueprint` (not a mock) so `app.register_blueprint()` doesn't complain.
+
+**POST /api/upload:**
+- Empty body → 400 `VALIDATION_ERROR`
+- `srcUrl` not a wiki URL → 400 `VALIDATION_ERROR`
+- `download_image` returns `None` → 500 `FILE_OPERATION_ERROR`
+- Missing target fields (`trproject`, `trlang`, `trfilename`) → 400 `VALIDATION_ERROR`
+- No OAuth session → 401 `AUTHENTICATION_ERROR`
+- File under 50MB, upload succeeds → 200, response includes `source` URL
+- File over 50MB → 202 with `task_id` from the queued Celery task
+
+**GET /api/preference:**
+- Unauthenticated → 200 with defaults (`wikipedia`, `en`, `skip_upload_selection: false`)
+
+**POST /api/preference:**
+- Missing `project` → 400
+- Missing `lang` → 400
+- Unauthenticated → 401
+- Authenticated save → 200 (creates a new User row)
+- Same user, second POST → 200 (updates the existing row, doesn't insert a duplicate)
+- GET after POST reflects the saved values — this is the closest to an integration test in the suite
+
+**GET /api/user_language:**
+- Unauthenticated → 200 with `"user_language": "en"`
+
+**POST /api/user_language:**
+- Missing `user_language` → 400
+- Unauthenticated → 401
+- Authenticated save → 200
+- GET after POST reflects the saved language
+
+**GET /api/get_wikitext:**
+- No query params → 200 with empty wikitext (the UI handles this case gracefully — no point erroring)
+- Partial params → same
+- All params, API responds → 200 with localized wikitext
+- All params, no revisions in response → 200 with empty wikitext
+- API timeout → 502
+- Connection error → 502
+
+**POST /api/edit_page:**
+- Missing `targetUrl` → 400
+- Missing `content` → 400
+- `targetUrl` is not a wiki URL → 400
+- Unauthenticated → 401
+- CSRF fetch times out → 502
+- `+\` CSRF token → 401 (expired OAuth session, same check as in `process_upload`)
+- Valid CSRF token, edit POST succeeds → 200
+
+**GET /api/user:**
+- Not logged in → 200 with `{"logged": false, "username": null}`
+- Logged in → 200 with `{"logged": true, "username": "WikiUser123"}`
+
+**GET /api/task_status/\<task_id\>:**
+- PENDING task → 200 with `task_id`, `status`, `result: null`
+- SUCCESS task → 200 with `result` populated
+- FAILURE task → 200 with `error` field containing the exception message
+
+---
+
+**Manually verifying the API response shape:**
+
+Start the app and send a bad request:
+
+```bash
+curl -X POST http://localhost:5000/api/upload \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+Expected response (HTTP 400):
+
+```json
+{
+  "success": false,
+  "data": {},
+  "errors": ["srcUrl is required"],
+  "error_details": {
+    "code": "VALIDATION_ERROR",
+    "message": "srcUrl is required",
+    "details": { "field": "srcUrl" }
+  }
+}
+```
+
+If you're seeing a plain HTML Flask error page instead of this JSON, `register_error_handlers(app)` didn't run — check `app.py` startup. If you're seeing a 200 with no body, you've got a bigger problem and maybe take a break first.
+
+**Check logs are being written:**
+
+```bash
+# Watch everything in real time
+tail -f logs/wikifile-transfer.log
+
+# Find specific errors fast
+grep "UPLOAD_ERROR" logs/wikifile-transfer.log
+
+# Parse the structured log if you need to
+python3 -c "
+import json
+with open('logs/wikifile-transfer-structured.jsonl') as f:
+    for line in f:
+        entry = json.loads(line)
+        if entry['level'] == 'ERROR':
+            print(entry['timestamp'], entry['message'])
+"
+```
+
+---
+
+## Adding a new exception
+
+1. Add the class to `exceptions.py` inheriting from `WikifileTransferError`. Pick a specific `error_code` — make it obvious (`RATE_LIMIT_ERROR` not `ERROR_7`).
+2. Add a handler in `error_handlers.py` calling `create_error_response()` with the right HTTP status.
+3. Register it in `register_error_handlers()`.
+4. Raise it in application code with `raise YourNewError("message", ...)`.
+
+Don't skip step 3. Flask falls through to `handle_generic_exception()` for anything unregistered, which returns a generic 500 and throws away all the structured context the exception was carrying. You'll spend time wondering why your nicely typed exception turned into a useless 500 with no details.

--- a/TEMP_FILE_CLEANUP.md
+++ b/TEMP_FILE_CLEANUP.md
@@ -1,0 +1,251 @@
+# Temp File Cleanup
+
+**Task:** T415717 | **Branch:** `Temp_File_Cleanup_T415717_backend`
+
+---
+
+## Overview
+
+So here's a fun little problem that nobody noticed until someone looked at the server disk space and went, "hm, that's a lot of mystery JPEGs."
+
+Every time a user transferred a file, the app downloaded it to `temp_images/`, did its thing, and then... just left it there. Forever. No cleanup on success. No cleanup on failure. No cleanup if a validation error fired halfway through. The files just piled up like empty pizza boxes in a college dorm — technically harmless at first, but eventually you're going to have a problem.
+
+This PR fixes that. Three things changed:
+
+1. `cleanup_temp_file()` — a shared helper that deletes a temp file without exploding if it doesn't exist
+2. Sync uploads in `app.py` — a `try/finally` guarantees cleanup whether the upload succeeded, failed, or blew up mid-validation
+3. Async uploads in `tasks.py` — a `_should_cleanup` flag ensures the task cleans up on terminal exit, but leaves the file alone during retries
+
+No new dependencies. No new config. The `temp_images/` directory still works exactly as before — it's just not a permanent archive anymore.
+
+---
+
+## Background — what was actually leaking
+
+There were three leak scenarios, each slightly different:
+
+**Scenario 1: Sync upload succeeds (< 50 MB)**
+
+```
+download_image()  →  temp file created ✓
+process_upload()  →  file sent to wiki  ✓
+route returns     →  temp file... still there ✗
+```
+
+The happy path leaked. Every successful upload left a file behind.
+
+**Scenario 2: Validation or auth fails after download**
+
+```
+download_image()            →  temp file created ✓
+validate target fields      →  ValidationError raised ✗
+Flask error handler returns →  temp file... still there ✗
+```
+
+If `trproject`, `trlang`, or `trfilename` were missing from the request, or if the user wasn't logged in, the exception blew past the download without anyone cleaning up the file that had just been written to disk. Surprise: the error handler doesn't know about temp files.
+
+**Scenario 3: Async task exits (> 50 MB, success or final failure)**
+
+```
+upload_image_task() runs  →  file uploaded (or fails after 3 retries)
+task returns result dict  →  temp file... still there ✗
+```
+
+The Celery task ran to completion — success or exhausted retries — and just left the file sitting there. The task owns the file for its entire lifetime and is the only thing that can reliably clean it up. But it wasn't.
+
+---
+
+## Files changed
+
+| File | What happened |
+|---|---|
+| `utils.py` | Added `cleanup_temp_file()` helper; fixed partial-file leak on write failure in `download_image()` |
+| `app.py` | `upload()` route now uses `try/finally` to guarantee cleanup for sync uploads |
+| `tasks.py` | `upload_image_task()` uses `_should_cleanup` flag + `finally` to clean up on terminal outcomes only |
+
+---
+
+## The helper — `cleanup_temp_file()`
+
+Lives in `utils.py`. Takes a file path, deletes the file if it exists, logs what happened, and returns.
+
+```python
+def cleanup_temp_file(file_path):
+    """Remove a temp file from disk. Silently ignores missing files."""
+    if not file_path:
+        return
+    try:
+        if os.path.exists(file_path):
+            os.remove(file_path)
+            logger.info(f"Cleaned up temp file: {file_path}")
+    except OSError as e:
+        logger.warning(f"Failed to remove temp file {file_path}: {e}")
+```
+
+It's intentionally boring. It doesn't raise. It doesn't care if the file is already gone (race condition, manual deletion, whatever). It just tries to clean up and logs what it does. If you call it with `None`, it exits immediately — that handles the case where `download_image()` failed before a path was even assigned.
+
+Both `app.py` and `tasks.py` import it from `utils`.
+
+---
+
+## `app.py` — sync upload cleanup
+
+The fix is a `try/finally` block wrapping everything that happens after the download:
+
+```python
+file_path = 'temp_images/' + downloaded_filename
+handed_off_to_task = False
+
+try:
+    # validate fields, check auth, get file size ...
+
+    if file_size < 50 * 1024 * 1024:
+        resp = process_upload(...)
+        return success_response(data=resp)
+    else:
+        task = upload_image_task.delay(file_path, ...)
+        handed_off_to_task = True
+        return success_response(data={"task_id": task.id}, status_code=202)
+
+finally:
+    if not handed_off_to_task:
+        cleanup_temp_file(file_path)
+```
+
+The `handed_off_to_task` flag is the key. For sync uploads (< 50 MB), `finally` always runs — even when a `ValidationError` or `AuthenticationError` is raised before we get to `process_upload()`. The file gets deleted.
+
+For async uploads (> 50 MB), we flip the flag before returning. The `finally` still runs, but sees `handed_off_to_task = True` and skips cleanup. The Celery task owns the file from that point on.
+
+Python's `finally` runs even after a `return` statement — the response is already set when cleanup happens, so there's no timing issue.
+
+---
+
+## `tasks.py` — async task cleanup
+
+Celery tasks have a retry mechanism, which makes cleanup non-trivial. The file needs to survive retries (otherwise attempt #2 opens a file that no longer exists) but get deleted once the task is truly done.
+
+The solution is a `_should_cleanup` flag:
+
+```python
+_should_cleanup = True  # flipped to False only before self.retry()
+
+try:
+    ...
+    except requests.exceptions.Timeout as e:
+        if self.request.retries < self.max_retries:
+            _should_cleanup = False   # ← file must survive the retry
+            raise self.retry(exc=e)
+    ...
+    except Retry:
+        raise   # ← _should_cleanup is False here, finally won't delete the file
+
+    except Exception as e:
+        ...
+        return {"success": False, ...}
+
+finally:
+    if _should_cleanup:
+        cleanup_temp_file(file_path)
+```
+
+When `self.retry()` is called:
+- `_should_cleanup` is set to `False`
+- `self.retry()` raises a `Retry` exception
+- `except Retry: raise` re-raises it
+- `finally` runs — sees `_should_cleanup = False` — skips cleanup
+- Celery reschedules the task with the file still on disk
+
+When the task exits for real (success, final failure, or unexpected exception):
+- `_should_cleanup` is still `True`
+- `finally` runs — sees `_should_cleanup = True` — deletes the file
+
+**Why not just put cleanup in each `return` statement?**
+
+The task has fourteen return points. Adding `cleanup_temp_file(file_path)` before each one would work, but it's fragile — someone adds a new early return someday and forgets the cleanup line, and we're back to leaking. The flag-plus-finally approach makes cleanup automatic for any path through the code, as long as it's not a retry.
+
+---
+
+## The partial-file edge case in `download_image()`
+
+There was a smaller leak in `utils.py` that's also fixed here. If `f.write(r.content)` raised an `OSError` partway through writing:
+
+```python
+with open(file_path, "wb") as f:
+    f.write(r.content)   # ← OSError here closes the handle but leaves the partial file
+```
+
+The file handle gets closed (the `with` handles that), but a partial file stays on disk. The existing `except OSError` handler logged and re-raised, but didn't clean up. Now it does:
+
+```python
+except OSError as e:
+    partial = file_path if "file_path" in locals() else None
+    cleanup_temp_file(partial)
+    ...
+    raise FileOperationError(...) from e
+```
+
+This is a rare case — disk-full or permissions errors — but partial files are worse than no files, so we clean them up.
+
+---
+
+## Testing
+
+The existing test suite covers the behaviour changes:
+
+- `tests/utils_test.py` — disk write failure → `FileOperationError` raised (partial cleanup tested implicitly via mock)
+- `tests/tasks_test.py` — retry scenarios verify the task re-raises `Retry` correctly; terminal failure scenarios verify the dict is returned
+- `tests/app_test.py` — validation-fail-after-download scenarios return the expected 400; sync upload success returns 200
+
+**Run the full suite:**
+
+```bash
+pytest tests/ -v
+```
+
+**Manually check cleanup is happening:**
+
+```bash
+# watch the log while running a transfer
+tail -f logs/wikifile-transfer.log | grep "temp"
+
+# before the fix, this directory would grow indefinitely
+ls -la temp_images/
+```
+
+After a successful transfer, `temp_images/` should be empty (or contain only files from in-flight requests). If you see files accumulating, something isn't being cleaned up — check the log for "Failed to remove temp file" warnings.
+
+---
+
+## What this doesn't change
+
+- The `temp_images/` directory is still created automatically by `download_image()` if it doesn't exist
+- No changes to the upload API contract — request/response shape is identical
+- No changes to retry behavior — still 3 retries, 60s delay, same retry conditions
+- No new dependencies
+
+---
+
+## Adding cleanup to new upload paths
+
+If you add a new route that calls `download_image()`, the pattern is:
+
+```python
+filename = download_image(...)
+file_path = f"temp_images/{filename}"
+handed_off = False
+
+try:
+    # ... your route logic
+    if async_path:
+        some_task.delay(file_path, ...)
+        handed_off = True
+        return ...
+    else:
+        do_sync_thing(file_path)
+        return ...
+finally:
+    if not handed_off:
+        cleanup_temp_file(file_path)
+```
+
+And if you add a new Celery task that receives a `file_path`, follow the `_should_cleanup` pattern from `tasks.py`. The `finally` approach is the right one — don't try to add cleanup at every individual return statement.

--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 from flask import send_from_directory
-from flask import Flask, request, session, jsonify, render_template
+from flask import Flask, request, session, jsonify
 from flask_mwoauth import MWOAuth
 from flask_migrate import Migrate
 from utils import download_image, get_localized_wikitext, getHeader, process_upload
@@ -10,17 +10,23 @@ import requests_oauthlib
 import requests
 import os
 import yaml
-import re 
+import re
 import urllib.parse
 from model import db, User
-import logging
 from celeryWorker import app as celery_app
 from tasks import upload_image_task
 from celery.result import AsyncResult
-
-# Configure logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+from logging_config import setup_logging, get_logger, log_timed_api_call
+from exceptions import (
+    ValidationError,
+    WikiAPIError,
+    FileOperationError,
+    DatabaseError,
+    AuthenticationError,
+    UploadError,
+    ResourceNotFoundError
+)
+from error_handlers import register_error_handlers, success_response
 
 app = Flask(__name__)
 
@@ -31,9 +37,12 @@ app.config.update(yaml.safe_load(open(os.path.join(__dir__, 'config.yaml'))))
 # Get variables
 ENV = app.config['ENV']
 BASE_URL = app.config['OAUTH_MWURI']
-API_ENDPOINT = BASE_URL + '/api.php'
 CONSUMER_KEY = app.config['CONSUMER_KEY']
 CONSUMER_SECRET = app.config['CONSUMER_SECRET']
+
+# Now that ENV is known, set up logging correctly for this environment
+setup_logging(env=ENV)
+logger = get_logger(__name__)
 
 # Enable CORS and Debugging in Dev mode
 if ENV == 'dev':
@@ -44,20 +53,21 @@ if ENV == 'dev':
 db.init_app(app)
 migrate = Migrate(app, db)
 
-# Register blueprint to app
+# Register MediaWiki OAuth blueprint
 MW_OAUTH = MWOAuth(
     base_url=BASE_URL,
     consumer_key=CONSUMER_KEY,
     consumer_secret=CONSUMER_SECRET,
-    user_agent= getHeader()['User-Agent']
+    user_agent=getHeader()['User-Agent']
 )
 app.register_blueprint(MW_OAUTH.bp)
+
+# Wire custom exceptions to consistent JSON error responses
+register_error_handlers(app)
 
 
 @app.route('/index', methods=['GET'])
 @app.route("/")
-# def index():
-#     return render_template('index.html')
 def serve():
     return send_from_directory("frontend/build", "index.html")
 
@@ -65,71 +75,81 @@ def serve():
 def serve_static(path):
     return send_from_directory("frontend/build/static", path)
 
+
 @app.route('/api/upload', methods=['POST'])
 def upload():
-    if request.method == 'POST':
-        data = request.get_json()
-        src_url = urllib.parse.unquote(data.get('srcUrl'))
-        match = re.findall(r"(\w+)\.(\w+)\.org/wiki/", src_url)
+    data = request.get_json()
 
-        src_project = match[0][1]
-        src_lang = match[0][0]
-        src_filename = src_url.split('/')[-1]
-        src_fileext = src_filename.split('.')[-1]
+    # Validate srcUrl is present and is a valid wiki URL
+    src_url = data.get('srcUrl') if data else None
+    if not src_url:
+        raise ValidationError("srcUrl is required", field="srcUrl")
+    src_url = urllib.parse.unquote(src_url)
 
-        # Downloading the source file and getting saved file name
-        downloaded_filename = download_image(src_project, src_lang, src_filename)
+    match = re.findall(r"(\w+)\.(\w+)\.org/wiki/", src_url)
+    if not match:
+        raise ValidationError("srcUrl must be a valid wiki URL", field="srcUrl")
 
-        # Getting Target Details
-        tr_project = data.get('trproject')
-        tr_lang = data.get('trlang')
-        tr_filename = data.get('trfilename')
-        tr_filename = urllib.parse.unquote(tr_filename)
-        tr_endpoint = "https://" + tr_lang + "." + tr_project + ".org/w/api.php"
+    src_project = match[0][1]
+    src_lang = match[0][0]
+    src_filename = src_url.split('/')[-1]
+    src_fileext = src_filename.split('.')[-1]
 
-        # Authenticate Session
-        ses = authenticated_session()
+    # Download source file and raise if download fails
+    downloaded_filename = download_image(src_project, src_lang, src_filename)
+    if downloaded_filename is None:
+        raise FileOperationError(
+            "Failed to download source file",
+            operation="download",
+            file_path=src_filename
+        )
 
-        # Check whether we have enough data or not
-        if None not in (downloaded_filename, tr_filename, src_fileext, ses):
-            file_path = 'temp_images/' + downloaded_filename
-            file_size = os.path.getsize(file_path)
+    # Validate target wiki fields
+    tr_project = data.get('trproject')
+    tr_lang = data.get('trlang')
+    tr_filename = data.get('trfilename')
 
-            if file_size < 50 * 1024 * 1024:  # 50 MB
-                # Process synchronously
-                resp = process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses)
-                if resp is None:
-                    return jsonify({"success": False, "data": {}, "errors": ["Upload failed"]}), 500
+    if not all([tr_project, tr_lang, tr_filename]):
+        raise ValidationError("trproject, trlang, and trfilename are all required")
 
-                resp["source"] = src_url
+    tr_filename = urllib.parse.unquote(tr_filename)
+    tr_endpoint = "https://" + tr_lang + "." + tr_project + ".org/w/api.php"
 
-                return jsonify({
-                    "success": True,
-                    "data": resp,
-                    "errors": []
-                }), 200
-            else:
-                # Process asynchronously using Celery
-                OAuthObj = {
-                    "consumer_key": CONSUMER_KEY,
-                    "consumer_secret": CONSUMER_SECRET,
-                    "key": session['mwoauth_access_token']['key'],
-                    "secret": session['mwoauth_access_token']['secret']
-                }
-                task = upload_image_task.delay(file_path, tr_filename, src_fileext, tr_endpoint, OAuthObj)
-                return jsonify({"success": True, "task_id": task.id}), 202
-        else:
-            return jsonify({"success": False, "data": {}, "errors": ["Not enough data"]}), 400
+    # Require authenticated session before proceeding
+    ses = authenticated_session()
+    if ses is None:
+        raise AuthenticationError("You must be logged in to upload files")
+
+    file_path = 'temp_images/' + downloaded_filename
+    file_size = os.path.getsize(file_path)
+
+    if file_size < 50 * 1024 * 1024:  # files under 50 MB upload synchronously
+        resp = process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses)
+        if resp is None:
+            raise UploadError("Upload to target wiki failed", upload_type="sync")
+
+        resp["source"] = src_url
+        return success_response(data=resp)
+
     else:
-        return jsonify({"success": False, "data": {}, "errors": ["Invalid Request"]}), 400
+        # Files over 50 MB are queued as a Celery async task
+        OAuthObj = {
+            "consumer_key": CONSUMER_KEY,
+            "consumer_secret": CONSUMER_SECRET,
+            "key": session['mwoauth_access_token']['key'],
+            "secret": session['mwoauth_access_token']['secret']
+        }
+        task = upload_image_task.delay(file_path, tr_filename, src_fileext, tr_endpoint, OAuthObj)
+        return success_response(data={"task_id": task.id}, status_code=202)
 
 
-@app.route('/api/preference', methods = ['GET', 'POST'])
+@app.route('/api/preference', methods=['GET', 'POST'])
 def preference():
 
     if request.method == 'GET':
         user = db_user()
 
+        # Return defaults for unauthenticated users
         user_project = "wikipedia"
         user_lang = "en"
         skip_upload_selection = False
@@ -138,27 +158,29 @@ def preference():
             user_project = user.pref_project
             user_lang = user.pref_language
             skip_upload_selection = user.skip_upload_selection
-            
-        return jsonify(
-            {
-                "success": True,
-                "data": {
-                    "project": user_project,
-                    "lang": user_lang,
-                    "skip_upload_selection": skip_upload_selection
-                },
-                "error": []
-            }), 200
+
+        return success_response(data={
+            "project": user_project,
+            "lang": user_lang,
+            "skip_upload_selection": skip_upload_selection
+        })
 
     elif request.method == 'POST':
-        # Get the data
         data = request.get_json()
-        project = data.get('project')
-        lang = data.get('lang')
-        skip_upload_selection = data.get('skip_upload_selection')
 
-        # Add into database
+        # Validate required fields before touching the database
+        project = data.get('project') if data else None
+        lang = data.get('lang') if data else None
+        skip_upload_selection = data.get('skip_upload_selection') if data else None
+
+        if not all([project, lang]):
+            raise ValidationError("project and lang are required")
+
+        # Only authenticated users can save preferences
         cur_username = MW_OAUTH.get_current_user(True)
+        if not cur_username:
+            raise AuthenticationError("You must be logged in to save preferences")
+
         user = User.query.filter_by(username=cur_username).first()
 
         if user is None:
@@ -176,13 +198,14 @@ def preference():
 
         try:
             db.session.commit()
-            return jsonify({ "success": True, "data": {}, "errors": []}), 200
-        except:
+            return success_response()
+        except Exception as e:
             db.session.rollback()
-            return jsonify({ "success": False, "data": {}, "errors": ["Database Error"]}), 500
+            logger.error(f"Failed to save preferences: {e}", exc_info=True)
+            raise DatabaseError("Failed to save preferences", operation="commit")
 
     else:
-        return jsonify({ "success": False, "data": {}, "errors": ["Invalid Request"]}), 400
+        raise ValidationError("Only GET and POST requests are allowed on this endpoint")
 
 
 @app.route('/api/user_language', methods=['GET', 'POST'])
@@ -190,24 +213,26 @@ def languagePreference():
     if request.method == 'GET':
         user = db_user()
 
-        user_language = "en"  # Default language
+        # Return default language for unauthenticated users
+        user_language = "en"
         if user is not None:
             user_language = user.user_language
 
-        return jsonify(
-            {
-                "success": True,
-                "data": {
-                    "user_language": user_language
-                },
-                "error": []
-            }), 200
+        return success_response(data={"user_language": user_language})
 
     elif request.method == 'POST':
         data = request.get_json()
-        user_language = data.get('user_language')
 
+        # Validate required field
+        user_language = data.get('user_language') if data else None
+        if not user_language:
+            raise ValidationError("user_language is required", field="user_language")
+
+        # Only authenticated users can save language preference
         cur_username = MW_OAUTH.get_current_user(True)
+        if not cur_username:
+            raise AuthenticationError("You must be logged in to save language preference")
+
         user = User.query.filter_by(username=cur_username).first()
 
         if user is None:
@@ -218,13 +243,14 @@ def languagePreference():
 
         try:
             db.session.commit()
-            return jsonify({ "success": True, "data": {}, "errors": []}), 200
-        except:
+            return success_response()
+        except Exception as e:
             db.session.rollback()
-            return jsonify({ "success": False, "data": {}, "errors": ["Database Error"]}), 500
+            logger.error(f"Failed to save language preference: {e}", exc_info=True)
+            raise DatabaseError("Failed to save language preference", operation="commit")
 
     else:
-        return jsonify({ "success": False, "data": {}, "errors": ["Invalid Request"]}), 400
+        raise ValidationError("Only GET and POST requests are allowed on this endpoint")
 
 
 @app.route('/api/get_wikitext', methods=['GET'])
@@ -234,9 +260,9 @@ def get_wikitext():
     src_filename = request.args.get('src_filename')
     tr_lang = request.args.get('tr_lang')
 
-    # In any case, return the strings only with 200 status code
+    # Return empty wikitext when params are missing — UI handles this gracefully
     if not all([src_lang, src_project, src_filename, tr_lang]):
-        return jsonify({"wikitext": ""}), 200
+        return success_response(data={"wikitext": ""})
 
     src_endpoint = f"https://{src_lang}.{src_project}.org/w/api.php"
     content_params = {
@@ -251,94 +277,121 @@ def get_wikitext():
     }
 
     try:
-        response = requests.get(src_endpoint, params=content_params)
-        response.raise_for_status()
+        with log_timed_api_call(logger, src_endpoint, "GET") as context:
+            response = requests.get(src_endpoint, params=content_params, timeout=10)
+            response.raise_for_status()
+            context["status_code"] = response.status_code
 
         page_data = response.json().get("query", {}).get("pages", [])
 
         if page_data and page_data[0].get("revisions"):
             wikitext = page_data[0]["revisions"][0]["slots"]["main"]["content"]
             wikitext = get_localized_wikitext(wikitext, src_endpoint, tr_lang)
-
-            return jsonify({"wikitext": wikitext}), 200
+            return success_response(data={"wikitext": wikitext})
         else:
-            return jsonify({"wikitext": ""}), 200
-    except:
-        return jsonify({"wikitext": ""}), 200
+            return success_response(data={"wikitext": ""})
+
+    except requests.exceptions.Timeout:
+        raise WikiAPIError("MediaWiki API request timed out", api_endpoint=src_endpoint)
+    except requests.exceptions.RequestException as e:
+        raise WikiAPIError(f"MediaWiki API request failed: {str(e)}", api_endpoint=src_endpoint)
 
 
 @app.route('/api/edit_page', methods=['POST'])
 def editPage():
-    if request.method == 'POST':
-        data = request.get_json()
-        targetUrl = data.get('targetUrl')
-        content = data.get('content')
+    data = request.get_json()
 
-        match = re.findall(r"(\w+)\.(\w+)\.org/wiki/", targetUrl)
+    # Validate required fields
+    target_url = data.get('targetUrl') if data else None
+    content = data.get('content') if data else None
 
-        target_project = match[0][1]
-        target_lang = match[0][0]
-        target_filename = targetUrl.split('/')[-1]
+    if not target_url:
+        raise ValidationError("targetUrl is required", field="targetUrl")
+    if content is None:
+        raise ValidationError("content is required", field="content")
 
-        target_endpoint = "https://" + target_lang + "." + target_project + ".org/w/api.php"
+    match = re.findall(r"(\w+)\.(\w+)\.org/wiki/", target_url)
+    if not match:
+        raise ValidationError("targetUrl must be a valid wiki URL", field="targetUrl")
 
-        # Authenticate Session
-        ses = authenticated_session()
+    target_project = match[0][1]
+    target_lang = match[0][0]
+    target_filename = target_url.split('/')[-1]
+    target_endpoint = "https://" + target_lang + "." + target_project + ".org/w/api.php"
 
-        # API Parameter to get CSRF Token
-        csrf_param = {
-            "action": "query",
-            "meta": "tokens",
-            "format": "json"
-        }
+    # Require authenticated session before making any API calls
+    ses = authenticated_session()
+    if ses is None:
+        raise AuthenticationError("You must be logged in to edit pages")
 
-        response = requests.get(url=target_endpoint, params=csrf_param, auth=ses)
+    csrf_param = {
+        "action": "query",
+        "meta": "tokens",
+        "format": "json"
+    }
+
+    # Fetch CSRF token required by MediaWiki edit API
+    try:
+        with log_timed_api_call(logger, target_endpoint, "GET") as context:
+            response = requests.get(url=target_endpoint, params=csrf_param, auth=ses, timeout=10)
+            response.raise_for_status()
+            context["status_code"] = response.status_code
+
         csrf_token = response.json()["query"]["tokens"]["csrftoken"]
 
-        # API Parameters to edit the page
-        edit_params = {
-            "action": "edit",
-            "title": "File:" + target_filename.split(':')[1],
-            "token": csrf_token,
-            "format": "json",
-            "appendtext": content
-        }
+        # +\ is what MediaWiki returns when OAuth session isn't recognized — HTTP is still 200
+        if csrf_token == "+\\":
+            raise AuthenticationError("Invalid CSRF token — OAuth session may have expired")
 
-        response = requests.post(url=target_endpoint, data=edit_params, auth=ses)
+    except requests.exceptions.Timeout:
+        raise WikiAPIError("Timed out fetching CSRF token", api_endpoint=target_endpoint)
+    except (requests.exceptions.RequestException, KeyError) as e:
+        raise WikiAPIError(f"Failed to get CSRF token: {str(e)}", api_endpoint=target_endpoint)
 
-        if response.status_code == 200:
-            return jsonify({ "success": True, "data": {}, "errors": []}), 200
-        else:
-            return jsonify({ "success": False, "data": {}, "errors": ["Edit Error"]}), 500
+    edit_params = {
+        "action": "edit",
+        "title": "File:" + target_filename.split(':')[1],
+        "token": csrf_token,
+        "format": "json",
+        "appendtext": content
+    }
 
-    else:
-        return jsonify({ "success": False, "data": {}, "errors": ["Invalid Request"]}), 400
+    # Submit the edit with a longer timeout for large content
+    try:
+        with log_timed_api_call(logger, target_endpoint, "POST") as context:
+            response = requests.post(url=target_endpoint, data=edit_params, auth=ses, timeout=30)
+            response.raise_for_status()
+            context["status_code"] = response.status_code
+    except requests.exceptions.Timeout:
+        raise WikiAPIError("Timed out posting edit", api_endpoint=target_endpoint)
+    except requests.exceptions.RequestException as e:
+        raise WikiAPIError(f"Edit request failed: {str(e)}", api_endpoint=target_endpoint)
+
+    return success_response()
 
 
 @app.route('/api/user', methods=['GET'])
 def get_base_variables():
-    return jsonify({
+    return success_response(data={
         "logged": logged() is not None,
         "username": MW_OAUTH.get_current_user(True)
-    }), 200
+    })
+
 
 @app.route('/api/task_status/<task_id>', methods=['GET'])
 def get_task_status(task_id):
-    """
-    Endpoint to get the status and result of a Celery task.
-    """
     task = AsyncResult(task_id, app=celery_app)
-    response = {
+
+    data = {
         "task_id": task_id,
         "status": task.status,
         "result": task.result if task.successful() else None,
     }
-    
-    # If task failed, include error information
-    if task.failed():
-        response["error"] = str(task.result)
 
-    return jsonify(response), 200
+    if task.failed():
+        data["error"] = str(task.result)
+
+    return success_response(data=data)
 
 
 def authenticated_session():
@@ -350,23 +403,18 @@ def authenticated_session():
             resource_owner_secret=session['mwoauth_access_token']['secret']
         )
         return auth
-
     return None
 
 
-def db_user():
-    if logged():
-        user = User.query.filter_by(username=MW_OAUTH.get_current_user(True)).first()
-        return user
-    else:
-        return None
-
-
 def logged():
-    if MW_OAUTH.get_current_user(True) is not None:
-        return MW_OAUTH.get_current_user(True)
-    else:
-        return None
+    return MW_OAUTH.get_current_user(True)
+
+
+def db_user():
+    username = logged()
+    if username:
+        return User.query.filter_by(username=username).first()
+    return None
 
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ from flask import send_from_directory
 from flask import Flask, request, session, jsonify
 from flask_mwoauth import MWOAuth
 from flask_migrate import Migrate
-from utils import download_image, get_localized_wikitext, getHeader, process_upload
+from utils import download_image, get_localized_wikitext, getHeader, process_upload, cleanup_temp_file
 from flask_cors import CORS
 import requests_oauthlib
 import requests
@@ -104,43 +104,51 @@ def upload():
             file_path=src_filename
         )
 
-    # Validate target wiki fields
-    tr_project = data.get('trproject')
-    tr_lang = data.get('trlang')
-    tr_filename = data.get('trfilename')
-
-    if not all([tr_project, tr_lang, tr_filename]):
-        raise ValidationError("trproject, trlang, and trfilename are all required")
-
-    tr_filename = urllib.parse.unquote(tr_filename)
-    tr_endpoint = "https://" + tr_lang + "." + tr_project + ".org/w/api.php"
-
-    # Require authenticated session before proceeding
-    ses = authenticated_session()
-    if ses is None:
-        raise AuthenticationError("You must be logged in to upload files")
-
     file_path = 'temp_images/' + downloaded_filename
-    file_size = os.path.getsize(file_path)
+    handed_off_to_task = False
 
-    if file_size < 50 * 1024 * 1024:  # files under 50 MB upload synchronously
-        resp = process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses)
-        if resp is None:
-            raise UploadError("Upload to target wiki failed", upload_type="sync")
+    try:
+        # Validate target wiki fields
+        tr_project = data.get('trproject')
+        tr_lang = data.get('trlang')
+        tr_filename = data.get('trfilename')
 
-        resp["source"] = src_url
-        return success_response(data=resp)
+        if not all([tr_project, tr_lang, tr_filename]):
+            raise ValidationError("trproject, trlang, and trfilename are all required")
 
-    else:
-        # Files over 50 MB are queued as a Celery async task
-        OAuthObj = {
-            "consumer_key": CONSUMER_KEY,
-            "consumer_secret": CONSUMER_SECRET,
-            "key": session['mwoauth_access_token']['key'],
-            "secret": session['mwoauth_access_token']['secret']
-        }
-        task = upload_image_task.delay(file_path, tr_filename, src_fileext, tr_endpoint, OAuthObj)
-        return success_response(data={"task_id": task.id}, status_code=202)
+        tr_filename = urllib.parse.unquote(tr_filename)
+        tr_endpoint = "https://" + tr_lang + "." + tr_project + ".org/w/api.php"
+
+        # Require authenticated session before proceeding
+        ses = authenticated_session()
+        if ses is None:
+            raise AuthenticationError("You must be logged in to upload files")
+
+        file_size = os.path.getsize(file_path)
+
+        if file_size < 50 * 1024 * 1024:  # files under 50 MB upload synchronously
+            resp = process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses)
+            if resp is None:
+                raise UploadError("Upload to target wiki failed", upload_type="sync")
+
+            resp["source"] = src_url
+            return success_response(data=resp)
+
+        else:
+            # Files over 50 MB are queued as a Celery async task — the task owns cleanup
+            OAuthObj = {
+                "consumer_key": CONSUMER_KEY,
+                "consumer_secret": CONSUMER_SECRET,
+                "key": session['mwoauth_access_token']['key'],
+                "secret": session['mwoauth_access_token']['secret']
+            }
+            task = upload_image_task.delay(file_path, tr_filename, src_fileext, tr_endpoint, OAuthObj)
+            handed_off_to_task = True
+            return success_response(data={"task_id": task.id}, status_code=202)
+
+    finally:
+        if not handed_off_to_task:
+            cleanup_temp_file(file_path)
 
 
 @app.route('/api/preference', methods=['GET', 'POST'])

--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-
+from flask import send_from_directory
 from flask import Flask, request, session, jsonify, render_template
 from flask_mwoauth import MWOAuth
 from flask_migrate import Migrate
@@ -10,7 +10,7 @@ import requests_oauthlib
 import requests
 import os
 import yaml
-import re
+import re 
 import urllib.parse
 from model import db, User
 import logging
@@ -56,9 +56,14 @@ app.register_blueprint(MW_OAUTH.bp)
 
 @app.route('/index', methods=['GET'])
 @app.route("/")
-def index():
-    return render_template('index.html')
+# def index():
+#     return render_template('index.html')
+def serve():
+    return send_from_directory("frontend/build", "index.html")
 
+@app.route("/static/<path:path>")
+def serve_static(path):
+    return send_from_directory("frontend/build/static", path)
 
 @app.route('/api/upload', methods=['POST'])
 def upload():

--- a/config.yaml.bak
+++ b/config.yaml.bak
@@ -1,7 +1,7 @@
 ENV: dev # dev, prod
 SECRET_KEY: RandomeString
-CONSUMER_KEY: 
-CONSUMER_SECRET: 
+CONSUMER_KEY: dummyKey
+CONSUMER_SECRET:dummykey
 OAUTH_MWURI: https://meta.wikimedia.org/w
 SESSION_COOKIE_SECURE: True
 SESSION_REFRESH_EACH_REQUEST: False

--- a/error_handlers.py
+++ b/error_handlers.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Centralized Flask error handlers that turn raised exceptions into consistent JSON responses."""
+
+from flask import jsonify
+from werkzeug.exceptions import HTTPException
+from exceptions import (
+    WikifileTransferError,
+    ValidationError,
+    WikiAPIError,
+    FileOperationError,
+    DatabaseError,
+    OAuthError,
+    AuthenticationError,
+    UploadError,
+    ConfigurationError,
+    TaskError,
+    ResourceNotFoundError
+)
+from logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+# Builds the standard error JSON shape returned by all error handlers
+def create_error_response(error_code, message, details=None, status_code=500):
+    response = {
+        "success": False,
+        "data": {},
+        "errors": [message],
+        "error_details": {
+            "code": error_code,
+            "message": message,
+        }
+    }
+    if details:
+        response["error_details"]["details"] = details
+    return jsonify(response), status_code
+
+
+# Builds the standard success JSON shape returned by all successful routes
+def success_response(data=None, message=None, status_code=200):
+    response = {
+        "success": True,
+        "data": data or {},
+        "errors": []
+    }
+    if message:
+        response["message"] = message
+    return jsonify(response), status_code
+
+
+# Handles bad user input — returns 400
+def handle_validation_error(error):
+    logger.warning(f"Validation error: {error.message}")
+    return create_error_response(
+        error_code=error.error_code,
+        message=error.message,
+        details=error.details,
+        status_code=400
+    )
+
+
+# Handles Wikipedia API failures including timeouts and connection errors — returns 502
+def handle_wiki_api_error(error):
+    logger.error(f"Wiki API error: {error.message}")
+    return create_error_response(
+        error_code=error.error_code,
+        message=error.message,
+        details=error.details,
+        status_code=502
+    )
+
+
+# Handles file download, upload, or write failures — returns 500
+def handle_file_operation_error(error):
+    logger.error(f"File operation error: {error.message}")
+    return create_error_response(
+        error_code=error.error_code,
+        message=error.message,
+        details=error.details,
+        status_code=500
+    )
+
+
+# Handles database failures — hides internal details from user for security
+def handle_database_error(error):
+    logger.error(f"Database error: {error.message}", exc_info=True)
+    return create_error_response(
+        error_code=error.error_code,
+        message="A database error occurred. Please try again later.",
+        details={"operation": error.details.get("operation")},
+        status_code=500
+    )
+
+
+# Handles broken or expired OAuth tokens — returns 401
+# Token EXISTS but is invalid — different from user never logging in
+def handle_oauth_error(error):
+    logger.error(f"OAuth error: {error.message}")
+    return create_error_response(
+        error_code=error.error_code,
+        message="Authentication session is invalid. Please log in again.",
+        details={},
+        status_code=401
+    )
+
+
+# Handles unauthenticated requests — returns 401
+# User has NO token at all, never logged in
+def handle_authentication_error(error):
+    logger.warning(f"Authentication error: {error.message}")
+    return create_error_response(
+        error_code=error.error_code,
+        message=error.message,
+        details=error.details,
+        status_code=401
+    )
+
+
+# Handles failed wiki uploads — returns 500
+def handle_upload_error(error):
+    logger.error(f"Upload error: {error.message}")
+    return create_error_response(
+        error_code=error.error_code,
+        message=error.message,
+        details=error.details,
+        status_code=500
+    )
+
+
+# Handles missing or invalid config — hides config details from user for security
+def handle_configuration_error(error):
+    logger.critical(f"Configuration error: {error.message}")
+    return create_error_response(
+        error_code=error.error_code,
+        message="A configuration error occurred. Please contact the administrator.",
+        details={},
+        status_code=500
+    )
+
+
+# Handles Celery async task failures — returns 500
+def handle_task_error(error):
+    logger.error(f"Task error: {error.message}")
+    return create_error_response(
+        error_code=error.error_code,
+        message=error.message,
+        details=error.details,
+        status_code=500
+    )
+
+
+# Handles missing images or files — returns 404
+def handle_resource_not_found_error(error):
+    logger.info(f"Resource not found: {error.message}")
+    return create_error_response(
+        error_code=error.error_code,
+        message=error.message,
+        details=error.details,
+        status_code=404
+    )
+
+
+# Handles standard HTTP errors from werkzeug like 404, 405, etc
+def handle_http_exception(error):
+    logger.warning(f"HTTP exception: {error.code} - {error.description}")
+    return create_error_response(
+        error_code=f"HTTP_{error.code}",
+        message=error.description,
+        details={},
+        status_code=error.code
+    )
+
+
+# Catches any unexpected exception not handled by a specific handler
+def handle_generic_exception(error):
+    logger.error(f"Unexpected error: {str(error)}", exc_info=True)
+    return create_error_response(
+        error_code="INTERNAL_SERVER_ERROR",
+        message="An unexpected error occurred. Please try again later.",
+        details={},
+        status_code=500
+    )
+
+
+# Registers all error handlers with the Flask app — call this once in app.py
+def register_error_handlers(app):
+    app.register_error_handler(ValidationError, handle_validation_error)
+    app.register_error_handler(WikiAPIError, handle_wiki_api_error)
+    app.register_error_handler(FileOperationError, handle_file_operation_error)
+    app.register_error_handler(DatabaseError, handle_database_error)
+    app.register_error_handler(OAuthError, handle_oauth_error)
+    app.register_error_handler(AuthenticationError, handle_authentication_error)
+    app.register_error_handler(UploadError, handle_upload_error)
+    app.register_error_handler(ConfigurationError, handle_configuration_error)
+    app.register_error_handler(TaskError, handle_task_error)
+    app.register_error_handler(ResourceNotFoundError, handle_resource_not_found_error)
+    app.register_error_handler(HTTPException, handle_http_exception)
+    app.register_error_handler(Exception, handle_generic_exception)
+    logger.info("Error handlers registered")
+
+
+## What Changed — Only 3 Things

--- a/exceptions.py
+++ b/exceptions.py
@@ -1,0 +1,159 @@
+
+"""Custom exceptions to replace bare except blocks and make error tracking clearer across the app."""
+
+
+# Base class for all application errors
+class WikifileTransferError(Exception):
+
+    def __init__(self, message, error_code=None, details=None):
+        self.message = message
+        self.error_code = error_code or "GENERAL_ERROR"
+        self.details = details or {}
+        super().__init__(self.message)
+
+    def to_dict(self):
+        return {
+            "error_code": self.error_code,
+            "message": self.message,
+            "details": self.details
+        }
+
+
+# Raised when user input fails validation
+class ValidationError(WikifileTransferError):
+
+    def __init__(self, message, field=None, details=None):
+        error_details = details or {}
+        if field:
+            error_details["field"] = field
+        super().__init__(
+            message=message,
+            error_code="VALIDATION_ERROR",
+            details=error_details
+        )
+
+
+# Raised when a MediaWiki API call fails
+class WikiAPIError(WikifileTransferError):
+
+    def __init__(self, message, api_endpoint=None, status_code=None, details=None):
+        error_details = details or {}
+        if api_endpoint:
+            error_details["api_endpoint"] = api_endpoint
+        if status_code:
+            error_details["status_code"] = status_code
+        super().__init__(
+            message=message,
+            error_code="WIKI_API_ERROR",
+            details=error_details
+        )
+
+
+# Raised when a file download, write, or read operation fails
+class FileOperationError(WikifileTransferError):
+
+    def __init__(self, message, operation=None, file_path=None, details=None):
+        error_details = details or {}
+        if operation:
+            error_details["operation"] = operation
+        if file_path:
+            error_details["file_path"] = file_path
+        super().__init__(
+            message=message,
+            error_code="FILE_OPERATION_ERROR",
+            details=error_details
+        )
+
+
+# Raised when a database operation fails
+class DatabaseError(WikifileTransferError):
+
+    def __init__(self, message, operation=None, details=None):
+        error_details = details or {}
+        if operation:
+            error_details["operation"] = operation
+        super().__init__(
+            message=message,
+            error_code="DATABASE_ERROR",
+            details=error_details
+        )
+
+
+# Raised when an OAuth token is broken, expired, or rejected by the Wiki
+class OAuthError(WikifileTransferError):
+
+    def __init__(self, message, details=None):
+        super().__init__(
+            message=message,
+            error_code="OAUTH_ERROR",
+            details=details or {}
+        )
+
+
+# Raised when the user is not authenticated or the session is invalid
+class AuthenticationError(WikifileTransferError):
+
+    def __init__(self, message, details=None):
+        super().__init__(
+            message=message,
+            error_code="AUTHENTICATION_ERROR",
+            details=details or {}
+        )
+
+
+# Raised when a file upload to the target Wiki fails
+class UploadError(WikifileTransferError):
+
+    def __init__(self, message, upload_type=None, details=None):
+        error_details = details or {}
+        if upload_type:
+            error_details["upload_type"] = upload_type
+        super().__init__(
+            message=message,
+            error_code="UPLOAD_ERROR",
+            details=error_details
+        )
+
+
+# Raised when a required configuration key is missing or invalid
+class ConfigurationError(WikifileTransferError):
+
+    def __init__(self, message, config_key=None, details=None):
+        error_details = details or {}
+        if config_key:
+            error_details["config_key"] = config_key
+        super().__init__(
+            message=message,
+            error_code="CONFIGURATION_ERROR",
+            details=error_details
+        )
+
+
+# Raised when a Celery async task fails
+class TaskError(WikifileTransferError):
+
+    def __init__(self, message, task_id=None, details=None):
+        error_details = details or {}
+        if task_id:
+            error_details["task_id"] = task_id
+        super().__init__(
+            message=message,
+            error_code="TASK_ERROR",
+            details=error_details
+        )
+
+
+# Raised when a requested resource like an image or file does not exist
+class ResourceNotFoundError(WikifileTransferError):
+
+    def __init__(self, message, resource_type=None, resource_id=None, details=None):
+        error_details = details or {}
+        if resource_type:
+            error_details["resource_type"] = resource_type
+        if resource_id:
+            error_details["resource_id"] = resource_id
+        super().__init__(
+            message=message,
+            error_code="RESOURCE_NOT_FOUND",
+            details=error_details
+        )

--- a/logging_config.py
+++ b/logging_config.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Logging setup with rotating file handlers to keep track of app activity and errors."""
+
+import logging
+import logging.handlers
+import os
+import json
+from datetime import datetime
+import time 
+from contextlib import contextmanager
+from exceptions import WikifileTransferError
+
+# Formats each log record as a single-line JSON object for structured logging
+class JSONFormatter(logging.Formatter):
+
+    def format(self, record):
+        log_data = {
+            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "module": record.module,
+            "function": record.funcName,
+            "line": record.lineno,
+        }
+        # Include full exception details if the log record has one
+        if record.exc_info:
+            log_data["exception"] = {
+                "type": record.exc_info[0].__name__,
+                "message": str(record.exc_info[1]),
+                "traceback": self.formatException(record.exc_info)
+            }
+        # Include any extra context passed alongside the log message
+        if hasattr(record, "extra_data"):
+            log_data["extra"] = record.extra_data
+        return json.dumps(log_data)
+    
+class ContextFilter(logging.Filter):
+        """Adds contextual information to log records, such as request ID or user ID."""
+        def filter(self, record):
+         if not hasattr(record, "extra_data"):
+            record.extra_data = {}
+         return True
+
+            
+
+
+# Creates the logs/ directory and attaches rotating file handlers to the logger
+def setup_logging(app_name="wikifile-transfer", log_dir="logs", log_level=logging.INFO,env="dev"):
+    if not os.path.exists(log_dir):
+        os.makedirs(log_dir,exist_ok=True)
+
+    logger = logging.getLogger(app_name)
+    logger.setLevel(log_level)
+
+    # Clear existing handlers to avoid duplicate entries on repeated calls
+    logger.handlers.clear()
+
+    #add context filter to include extra data in all logs if there is an extra data
+    context_filter=ContextFilter()
+    logger.addFilter(context_filter)
+
+
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(module)s:%(funcName)s:%(lineno)d - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S"
+    )
+
+    # General log — captures everything INFO and above, rotates at 10MB
+    general_handler = logging.handlers.RotatingFileHandler(
+        filename=os.path.join(log_dir, f"{app_name}.log"),
+        maxBytes=10 * 1024 * 1024,
+        backupCount=5,
+        encoding="utf-8"
+    )
+    general_handler.setLevel(logging.INFO)
+    general_handler.setFormatter(formatter)
+    logger.addHandler(general_handler)
+
+    # Error log — captures only ERROR and CRITICAL for quick failure monitoring
+    error_handler = logging.handlers.RotatingFileHandler(
+        filename=os.path.join(log_dir, f"{app_name}-error.log"),
+        maxBytes=10 * 1024 * 1024,
+        backupCount=5,
+        encoding="utf-8"
+    )
+    error_handler.setLevel(logging.ERROR)
+    error_handler.setFormatter(formatter)
+    logger.addHandler(error_handler)
+
+    # Structured JSON log — same events as JSON objects for machine parsing
+    
+    json_handler = logging.handlers.RotatingFileHandler(
+        
+        filename=os.path.join(log_dir, f"{app_name}-structured.jsonl"),
+        maxBytes=10 * 1024 * 1024,
+        backupCount=5,
+        encoding="utf-8"
+    )
+    json_handler.setLevel(logging.INFO)
+    json_handler.setFormatter(JSONFormatter())
+    logger.addHandler(json_handler)
+
+    #Console Handler for development
+    if env=="dev":
+     console_handler = logging.StreamHandler()
+     console_handler.setLevel(logging.INFO)
+     console_formatter = logging.Formatter(
+        '%(asctime)s - %(levelname)s - %(module)s - %(message)s',
+        datefmt='%H:%M:%S'
+     )
+     console_handler.setFormatter(console_formatter)
+     logger.addHandler(console_handler)
+     logger.info(f"Logging configured — writing to {log_dir}/")
+    return logger
+
+
+# Returns a logger scoped under the wikifile-transfer namespace for the calling module
+def get_logger(name=None):
+    if name:
+        return logging.getLogger(f"wikifile-transfer.{name}")
+    return logging.getLogger("wikifile-transfer")
+
+
+# Logs a caught exception with its full stack trace and optional extra context
+def log_exception(logger, exception, extra_context=None):
+    extra_data = {
+        "exception_type": type(exception).__name__,
+        "exception_message": str(exception),
+    }
+    if extra_context:
+        extra_data.update(extra_context)
+
+    logger.error(
+        f"Exception occurred: {type(exception).__name__}: {str(exception)}",
+        exc_info=True,
+        extra={"extra_data": extra_data}
+    )
+
+
+# Logs a MediaWiki API call with its method, endpoint, status code, and result
+
+def log_api_call(logger, endpoint, method, status_code=None, duration=None, exception=None):
+    extra_data = {
+        "endpoint": endpoint,
+        "method": method,
+        "status_code": status_code,
+        "duration_seconds": duration,
+    }
+
+    if exception:
+        extra_data["exception_type"] = type(exception).__name__
+        extra_data["exception_message"] = str(exception)
+
+        logger.error(
+            f"API call failed: {method} {endpoint}",
+            exc_info=True,
+            extra={"extra_data": extra_data}
+        )
+    else:
+        logger.info(
+            f"API call: {method} {endpoint} — {status_code}",
+            extra={"extra_data": extra_data}
+        )
+
+
+from contextlib import contextmanager
+import time
+
+@contextmanager
+def log_timed_api_call(logger, endpoint, method):
+    start = time.time()
+    context = {}
+    try:
+        yield context
+    except Exception as e:
+        duration = time.time() - start
+
+        log_api_call(
+            logger,
+            endpoint,
+            method,
+            duration=duration,
+            exception=e
+        )
+        raise
+    else:
+        duration = time.time() - start
+
+        log_api_call(
+            logger,
+            endpoint,
+            method,
+            duration=duration,
+            status_code=context.get("status_code", 200)
+        )
+
+# Logs a file system operation such as download, upload, or write with its outcome
+def log_file_operation(logger, operation, file_path, success=True, error=None):
+    extra_data = {
+        "operation": operation,
+        "file_path": file_path,
+        "success": success,
+    }
+    if not success and error:
+        extra_data["error"] = error
+        logger.error(
+            f"File operation failed: {operation} — {file_path} — {error}",
+            extra={"extra_data": extra_data}
+        )
+    else:
+        logger.info(
+            f"File operation: {operation} — {file_path}",
+            extra={"extra_data": extra_data}
+        )
+
+
+# Logs a Celery async task lifecycle event such as started, completed, or failed
+def log_task_event(logger, task_id, task_name, status, error=None, progress=None):
+    extra_data = {
+        "task_id": task_id,
+        "task_name": task_name,
+        "status": status,
+    }
+    if progress:
+        extra_data["progress"] = progress
+    if error:
+        extra_data["error"] = error
+        logger.error(
+            f"Task failed: {task_name} [{task_id}] — {error}",
+            extra={"extra_data": extra_data}
+        )
+    else:
+        logger.info(
+            f"Task event: {task_name} [{task_id}] — {status}",
+            extra={"extra_data": extra_data}
+        )

--- a/tasks.py
+++ b/tasks.py
@@ -5,7 +5,7 @@ import requests_oauthlib
 import os
 from logging_config import get_logger, log_exception, log_task_event, log_timed_api_call, log_file_operation
 from exceptions import AuthenticationError, WikiAPIError, FileOperationError
-from utils import getHeader
+from utils import getHeader, cleanup_temp_file
 
 logger = get_logger(__name__)
 
@@ -23,6 +23,7 @@ def upload_image_task(self, file_path, tr_filename, src_fileext, tr_endpoint, OA
     """
     task_id = self.request.id
     full_filename = f"{tr_filename}.{src_fileext}"
+    _should_cleanup = True  # set False only before self.retry() so file survives retries
 
     logger.info(f"Task {task_id}: starting upload for {full_filename}")
     log_task_event(
@@ -102,6 +103,7 @@ def upload_image_task(self, file_path, tr_filename, src_fileext, tr_endpoint, OA
             error_msg = "Timeout while fetching CSRF token"
             logger.error(f"Task {task_id}: {error_msg}")
             if self.request.retries < self.max_retries:
+                _should_cleanup = False
                 raise self.retry(exc=e)
             log_task_event(logger, task_id=task_id, task_name="upload_image_task",
                            status="failed", error=error_msg)
@@ -111,6 +113,7 @@ def upload_image_task(self, file_path, tr_filename, src_fileext, tr_endpoint, OA
             error_msg = f"Failed to fetch CSRF token: {str(e)}"
             log_exception(logger, e, extra_context={"task_id": task_id, "step": "fetch_csrf_token"})
             if self.request.retries < self.max_retries:
+                _should_cleanup = False
                 raise self.retry(exc=e)
             log_task_event(logger, task_id=task_id, task_name="upload_image_task",
                            status="failed", error=error_msg)
@@ -176,6 +179,7 @@ def upload_image_task(self, file_path, tr_filename, src_fileext, tr_endpoint, OA
             log_file_operation(logger, "upload", file_path, success=False, error=error_msg)
             logger.error(f"Task {task_id}: {error_msg}")
             if self.request.retries < self.max_retries:
+                _should_cleanup = False
                 raise self.retry(exc=e)
             log_task_event(logger, task_id=task_id, task_name="upload_image_task",
                            status="failed", error=error_msg)
@@ -186,6 +190,7 @@ def upload_image_task(self, file_path, tr_filename, src_fileext, tr_endpoint, OA
             log_exception(logger, e, extra_context={"task_id": task_id, "step": "upload_file"})
             log_file_operation(logger, "upload", file_path, success=False, error=str(e))
             if self.request.retries < self.max_retries:
+                _should_cleanup = False
                 raise self.retry(exc=e)
             log_task_event(logger, task_id=task_id, task_name="upload_image_task",
                            status="failed", error=error_msg)
@@ -238,3 +243,9 @@ def upload_image_task(self, file_path, tr_filename, src_fileext, tr_endpoint, OA
         log_task_event(logger, task_id=task_id, task_name="upload_image_task",
                        status="failed", error=error_msg)
         return {"success": False, "data": {}, "errors": [error_msg]}
+
+    finally:
+        # Clean up the temp file on any terminal outcome (success or final failure).
+        # Skipped when self.retry() is raised so the file survives to the next attempt.
+        if _should_cleanup:
+            cleanup_temp_file(file_path)

--- a/tasks.py
+++ b/tasks.py
@@ -1,58 +1,240 @@
 from celeryWorker import app
+from celery.exceptions import Retry
 import requests
 import requests_oauthlib
 import os
+from logging_config import get_logger, log_exception, log_task_event, log_timed_api_call, log_file_operation
+from exceptions import AuthenticationError, WikiAPIError, FileOperationError
+from utils import getHeader
 
-@app.task(bind=True)
+logger = get_logger(__name__)
+
+
+@app.task(bind=True, max_retries=3, default_retry_delay=60)
 def upload_image_task(self, file_path, tr_filename, src_fileext, tr_endpoint, OAuthObj):
-    ses = requests_oauthlib.OAuth1(
-        client_key=OAuthObj["consumer_key"],
-        client_secret= OAuthObj["consumer_secret"],
-        resource_owner_key=OAuthObj["key"],
-        resource_owner_secret=OAuthObj["secret"]
+    """
+    Celery async task for uploading files over 50 MB to a target wiki.
+
+    Called by app.py when the uploaded file exceeds 50 MB.
+    Retries up to 3 times (60s delay) on network timeouts.
+
+    Returns a dict — never raises — so the frontend polls /api/task_status
+    and reads result.success to distinguish pass from fail.
+    """
+    task_id = self.request.id
+    full_filename = f"{tr_filename}.{src_fileext}"
+
+    logger.info(f"Task {task_id}: starting upload for {full_filename}")
+    log_task_event(
+        logger,
+        task_id=task_id,
+        task_name="upload_image_task",
+        status="started",
+        progress={"filename": full_filename, "endpoint": tr_endpoint}
     )
-    self.update_state(state='PROGRESS', meta={'current': 0, 'total': 100})
-    
-    # API Parameter to get CSRF Token
-    csrf_param = {
-        "action": "query",
-        "meta": "tokens",
-        "format": "json"
-    }
 
-    response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses)
-    csrf_token = response.json()["query"]["tokens"]["csrftoken"]
-
-    self.update_state(state='PROGRESS', meta={'current': 25, 'total': 100})
-
-    # API Parameter to upload the file
-    upload_param = {
-        "action": "upload",
-        "filename": tr_filename + "." + src_fileext,
-        "format": "json",
-        "token": csrf_token,
-        "ignorewarnings": 1
-    }
-
-    # Read the file for POST request
-    file = {
-        'file': open(file_path, 'rb')
-    }
-
-    response = requests.post(url=tr_endpoint, files=file, data=upload_param, auth=ses).json()
-
-    self.update_state(state='PROGRESS', meta={'current': 75, 'total': 100})
-
-    # Try block to get Link and URL
     try:
-        wikifile_url = response["upload"]["imageinfo"]["descriptionurl"]
-        file_link = response["upload"]["imageinfo"]["url"]
-    except KeyError:
-        return {"success": False, "data": {}, "errors": ["Upload failed"]}
+        # ─────────────────────────────────────
+        # Validate OAuth credentials dict
+        # ─────────────────────────────────────
+        required_keys = ["consumer_key", "consumer_secret", "key", "secret"]
+        missing_keys = [k for k in required_keys if k not in OAuthObj]
 
-    self.update_state(state='PROGRESS', meta={'current': 100, 'total': 100})
+        if missing_keys:
+            error_msg = f"Missing OAuth credentials: {', '.join(missing_keys)}"
+            logger.error(f"Task {task_id}: {error_msg}")
+            log_task_event(logger, task_id=task_id, task_name="upload_image_task",
+                           status="failed", error=error_msg)
+            return {"success": False, "data": {}, "errors": [error_msg]}
 
-    return {
-        "wikipage_url": wikifile_url,
-        "file_link": file_link
-    }
+        # ─────────────────────────────────────
+        # Build OAuth session
+        # ─────────────────────────────────────
+        try:
+            ses = requests_oauthlib.OAuth1(
+                client_key=OAuthObj["consumer_key"],
+                client_secret=OAuthObj["consumer_secret"],
+                resource_owner_key=OAuthObj["key"],
+                resource_owner_secret=OAuthObj["secret"]
+            )
+            logger.info(f"Task {task_id}: OAuth session created")
+        except Exception as e:
+            error_msg = f"Failed to create OAuth session: {str(e)}"
+            log_exception(logger, e, extra_context={"task_id": task_id, "step": "create_oauth_session"})
+            log_task_event(logger, task_id=task_id, task_name="upload_image_task",
+                           status="failed", error=error_msg)
+            return {"success": False, "data": {}, "errors": [error_msg]}
+
+        self.update_state(state="PROGRESS", meta={"current": 0, "total": 100, "status": "Initializing"})
+
+        # ─────────────────────────────────────
+        # Step 1 — Fetch CSRF token
+        # ─────────────────────────────────────
+        csrf_param = {"action": "query", "meta": "tokens", "format": "json"}
+
+        try:
+            logger.info(f"Task {task_id}: fetching CSRF token")
+
+            with log_timed_api_call(logger, tr_endpoint, "GET") as ctx:
+                response = requests.get(
+                    url=tr_endpoint, params=csrf_param,
+                    auth=ses, timeout=30, headers=getHeader()
+                )
+                response.raise_for_status()
+                ctx["status_code"] = response.status_code
+
+            csrf_token = response.json()["query"]["tokens"]["csrftoken"]
+
+            if csrf_token == "+\\":
+                raise AuthenticationError("Invalid CSRF token — OAuth session may have expired")
+
+            logger.info(f"Task {task_id}: CSRF token obtained")
+            self.update_state(state="PROGRESS", meta={"current": 25, "total": 100, "status": "Token obtained"})
+
+        except AuthenticationError:
+            # Auth errors are not retryable — return immediately
+            error_msg = "Invalid CSRF token — OAuth session may have expired"
+            log_task_event(logger, task_id=task_id, task_name="upload_image_task",
+                           status="failed", error=error_msg)
+            return {"success": False, "data": {}, "errors": [error_msg]}
+
+        except requests.exceptions.Timeout as e:
+            error_msg = "Timeout while fetching CSRF token"
+            logger.error(f"Task {task_id}: {error_msg}")
+            if self.request.retries < self.max_retries:
+                raise self.retry(exc=e)
+            log_task_event(logger, task_id=task_id, task_name="upload_image_task",
+                           status="failed", error=error_msg)
+            return {"success": False, "data": {}, "errors": [error_msg]}
+
+        except requests.exceptions.RequestException as e:
+            error_msg = f"Failed to fetch CSRF token: {str(e)}"
+            log_exception(logger, e, extra_context={"task_id": task_id, "step": "fetch_csrf_token"})
+            if self.request.retries < self.max_retries:
+                raise self.retry(exc=e)
+            log_task_event(logger, task_id=task_id, task_name="upload_image_task",
+                           status="failed", error=error_msg)
+            return {"success": False, "data": {}, "errors": [error_msg]}
+
+        except KeyError as e:
+            error_msg = f"Unexpected CSRF response format: missing {str(e)}"
+            logger.error(f"Task {task_id}: {error_msg}")
+            log_task_event(logger, task_id=task_id, task_name="upload_image_task",
+                           status="failed", error=error_msg)
+            return {"success": False, "data": {}, "errors": [error_msg]}
+
+        # ─────────────────────────────────────
+        # Step 2 — Upload file
+        # ─────────────────────────────────────
+        try:
+            if not os.path.exists(file_path):
+                error_msg = f"File not found before upload: {file_path}"
+                logger.error(f"Task {task_id}: {error_msg}")
+                log_task_event(logger, task_id=task_id, task_name="upload_image_task",
+                               status="failed", error=error_msg)
+                return {"success": False, "data": {}, "errors": [error_msg]}
+
+            file_size = os.path.getsize(file_path)
+            logger.info(f"Task {task_id}: uploading {file_path} ({file_size} bytes)")
+
+            upload_param = {
+                "action": "upload",
+                "filename": full_filename,
+                "format": "json",
+                "token": csrf_token,
+                "ignorewarnings": 1
+            }
+
+            self.update_state(state="PROGRESS", meta={"current": 50, "total": 100, "status": "Uploading file"})
+
+            with log_timed_api_call(logger, tr_endpoint, "POST") as ctx:
+                with open(file_path, "rb") as f:
+                    response = requests.post(
+                        url=tr_endpoint,
+                        files={"file": f},
+                        data=upload_param,
+                        auth=ses,
+                        timeout=180  # 3 min for large files
+                    )
+                response.raise_for_status()
+                ctx["status_code"] = response.status_code
+
+            result = response.json()
+            log_file_operation(logger, "upload", file_path, success=True)
+            self.update_state(state="PROGRESS", meta={"current": 75, "total": 100, "status": "Processing result"})
+
+        except OSError as e:
+            error_msg = f"Could not read file for upload: {str(e)}"
+            log_exception(logger, e, extra_context={"task_id": task_id, "step": "read_file", "file_path": file_path})
+            log_file_operation(logger, "upload", file_path, success=False, error=str(e))
+            log_task_event(logger, task_id=task_id, task_name="upload_image_task",
+                           status="failed", error=error_msg)
+            return {"success": False, "data": {}, "errors": [error_msg]}
+
+        except requests.exceptions.Timeout as e:
+            error_msg = "Timeout while uploading file"
+            log_file_operation(logger, "upload", file_path, success=False, error=error_msg)
+            logger.error(f"Task {task_id}: {error_msg}")
+            if self.request.retries < self.max_retries:
+                raise self.retry(exc=e)
+            log_task_event(logger, task_id=task_id, task_name="upload_image_task",
+                           status="failed", error=error_msg)
+            return {"success": False, "data": {}, "errors": [error_msg]}
+
+        except requests.exceptions.RequestException as e:
+            error_msg = f"Failed to upload file: {str(e)}"
+            log_exception(logger, e, extra_context={"task_id": task_id, "step": "upload_file"})
+            log_file_operation(logger, "upload", file_path, success=False, error=str(e))
+            if self.request.retries < self.max_retries:
+                raise self.retry(exc=e)
+            log_task_event(logger, task_id=task_id, task_name="upload_image_task",
+                           status="failed", error=error_msg)
+            return {"success": False, "data": {}, "errors": [error_msg]}
+
+        # ─────────────────────────────────────
+        # Step 3 — Validate upload result
+        # ─────────────────────────────────────
+        upload_result = result.get("upload", {})
+
+        if upload_result.get("result") != "Success":
+            error_info = upload_result.get("error", {})
+            error_msg = f"Upload failed: {error_info.get('info', 'Unknown error')}"
+            logger.error(f"Task {task_id}: {error_msg}")
+            log_task_event(logger, task_id=task_id, task_name="upload_image_task",
+                           status="failed", error=error_msg)
+            return {"success": False, "data": {}, "errors": [error_msg]}
+
+        if "imageinfo" not in upload_result:
+            error_msg = "Upload succeeded but no imageinfo returned"
+            logger.error(f"Task {task_id}: {error_msg}")
+            log_task_event(logger, task_id=task_id, task_name="upload_image_task",
+                           status="failed", error=error_msg)
+            return {"success": False, "data": {}, "errors": [error_msg]}
+
+        wikifile_url = upload_result["imageinfo"]["descriptionurl"]
+        file_link = upload_result["imageinfo"]["url"]
+
+        self.update_state(state="PROGRESS", meta={"current": 100, "total": 100, "status": "Complete"})
+        log_task_event(
+            logger, task_id=task_id, task_name="upload_image_task",
+            status="completed",
+            progress={"filename": full_filename, "wikipage_url": wikifile_url}
+        )
+        logger.info(f"Task {task_id}: upload complete — {full_filename}")
+
+        return {
+            "success": True,
+            "wikipage_url": wikifile_url,
+            "file_link": file_link
+        }
+
+    except Retry:
+        # Re-raise Celery Retry exceptions so they are not swallowed by the catch-all below
+        raise
+
+    except Exception as e:
+        error_msg = f"Unexpected error in upload task: {str(e)}"
+        log_exception(logger, e, extra_context={"task_id": task_id, "filename": full_filename})
+        log_task_event(logger, task_id=task_id, task_name="upload_image_task",
+                       status="failed", error=error_msg)
+        return {"success": False, "data": {}, "errors": [error_msg]}

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -1,0 +1,573 @@
+"""
+Tests for Flask routes in app.py
+
+STRATEGY
+========
+app.py has a module-level side effect that we must neutralize before the first
+import: `from flask_mwoauth import MWOAuth` creates an MW_OAUTH object whose
+`get_current_user()` method tests need to control.
+
+We stub flask_mwoauth in sys.modules BEFORE importing app so that MW_OAUTH
+becomes a MagicMock we can configure per-test. We keep MW_OAUTH.bp as a real
+Flask Blueprint so that app.register_blueprint() does not fail.
+
+After import we:
+  - Override SQLALCHEMY_DATABASE_URI to SQLite in-memory (no MySQL needed)
+  - Set TESTING=True so Flask propagates exceptions through registered handlers
+  - Create all tables once per test module with db.create_all()
+
+ROUTES COVERED
+==============
+  POST /api/upload           — validation, auth check, sync and async paths
+  GET  /api/preference       — defaults for unauthenticated users
+  POST /api/preference       — validation, auth, DB save + update
+  GET  /api/user_language    — defaults for unauthenticated users
+  POST /api/user_language    — validation, auth, DB save
+  GET  /api/get_wikitext     — missing params, success, timeout
+  POST /api/edit_page        — validation, auth, CSRF fetch, edit success
+  GET  /api/user             — logged/username fields
+  GET  /api/task_status/<id> — PENDING, SUCCESS, FAILURE states
+
+HOW TO RUN
+==========
+  pytest tests/app_test.py -v
+"""
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from unittest.mock import MagicMock, patch
+from contextlib import contextmanager
+from flask import Blueprint
+
+# ─── Stub flask_mwoauth BEFORE importing app ──────────────────────────────────
+# MW_OAUTH.bp must be a real Blueprint; everything else can be a MagicMock.
+_fake_bp = Blueprint("mwoauth", __name__)
+_mock_mwoauth_inst = MagicMock()
+_mock_mwoauth_inst.bp = _fake_bp
+_mock_mwoauth_mod = MagicMock()
+_mock_mwoauth_mod.MWOAuth.return_value = _mock_mwoauth_inst
+sys.modules.setdefault("flask_mwoauth", _mock_mwoauth_mod)
+
+# ─── Now safe to import the Flask app ────────────────────────────────────────
+from app import app as flask_app, MW_OAUTH  # noqa: E402
+from model import db                         # noqa: E402
+
+
+# ─── Shared mock for log_timed_api_call ──────────────────────────────────────
+# app.py does:  with log_timed_api_call(logger, endpoint, method) as ctx:
+#                   ctx["status_code"] = ...
+# Our fake yields a dict so ctx["status_code"] works without a real logger.
+@contextmanager
+def _mock_timed(logger, endpoint, method):
+    yield {}
+
+
+# ─── Pytest fixtures ──────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def client():
+    """
+    Flask test client backed by an in-memory SQLite DB.
+    Created once per test module; DB tables are created on entry and dropped on exit.
+    """
+    flask_app.config["TESTING"] = True
+    flask_app.config["WTF_CSRF_ENABLED"] = False
+    flask_app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+
+    with flask_app.app_context():
+        db.create_all()
+        with flask_app.test_client() as c:
+            yield c
+        db.drop_all()
+
+
+# ─── Auth helpers ─────────────────────────────────────────────────────────────
+
+def _set_oauth_session(client):
+    """Inject a fake OAuth token into the test client's session."""
+    with client.session_transaction() as sess:
+        sess["mwoauth_access_token"] = {"key": "fake_key", "secret": "fake_secret"}
+
+
+def _clear_oauth_session(client):
+    """Remove the OAuth token from the test client's session."""
+    with client.session_transaction() as sess:
+        sess.pop("mwoauth_access_token", None)
+
+
+# ─── Shared data ──────────────────────────────────────────────────────────────
+
+VALID_WIKI_URL = "https://en.wikipedia.org/wiki/File:Example.jpg"
+VALID_UPLOAD_BODY = {
+    "srcUrl": VALID_WIKI_URL,
+    "trproject": "wikipedia",
+    "trlang": "fr",
+    "trfilename": "File%3AExample.jpg",
+}
+
+
+# =============================================================================
+# POST /api/upload
+# =============================================================================
+
+class TestUploadValidation:
+    """Input validation happens before any network call is made."""
+
+    def test_no_body_returns_400(self, client):
+        resp = client.post("/api/upload", json={})
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert data["success"] is False
+        assert data["error_details"]["code"] == "VALIDATION_ERROR"
+
+    def test_missing_src_url_returns_400(self, client):
+        resp = client.post("/api/upload", json={"trproject": "wikipedia"})
+        assert resp.status_code == 400
+        assert resp.get_json()["error_details"]["code"] == "VALIDATION_ERROR"
+
+    def test_non_wiki_src_url_returns_400(self, client):
+        resp = client.post("/api/upload", json={"srcUrl": "https://example.com/notawiki"})
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert data["error_details"]["code"] == "VALIDATION_ERROR"
+
+    def test_download_failure_returns_500(self, client):
+        # download_image returns None → FileOperationError → 500
+        with patch("app.download_image", return_value=None):
+            resp = client.post("/api/upload", json={"srcUrl": VALID_WIKI_URL})
+        assert resp.status_code == 500
+        assert resp.get_json()["success"] is False
+
+    def test_missing_tr_fields_returns_400(self, client):
+        # srcUrl valid, download succeeds, but target fields are all absent
+        with patch("app.download_image", return_value="file.jpg"):
+            resp = client.post("/api/upload", json={"srcUrl": VALID_WIKI_URL})
+        assert resp.status_code == 400
+        assert resp.get_json()["error_details"]["code"] == "VALIDATION_ERROR"
+
+
+class TestUploadAuthentication:
+    """Unauthenticated requests are rejected before touching the wiki API."""
+
+    def test_no_session_returns_401(self, client):
+        _clear_oauth_session(client)
+        with patch("app.download_image", return_value="file.jpg"), \
+             patch("app.authenticated_session", return_value=None):
+            resp = client.post("/api/upload", json=VALID_UPLOAD_BODY)
+        assert resp.status_code == 401
+        assert resp.get_json()["error_details"]["code"] == "AUTHENTICATION_ERROR"
+
+
+class TestUploadSuccess:
+    """Successful upload — sync path (< 50 MB) and async path (≥ 50 MB)."""
+
+    def test_small_file_returns_200_with_source(self, client):
+        _set_oauth_session(client)
+        upload_result = {
+            "file_link": "https://upload.wikimedia.org/test.jpg",
+            "wikipage_url": "https://commons.wikimedia.org/wiki/File:Example.jpg",
+        }
+        with patch("app.download_image", return_value="file.jpg"), \
+             patch("app.authenticated_session", return_value=MagicMock()), \
+             patch("app.os.path.getsize", return_value=1024), \
+             patch("app.process_upload", return_value=upload_result):
+            resp = client.post("/api/upload", json=VALID_UPLOAD_BODY)
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert "source" in data["data"]
+        assert data["data"]["source"] == VALID_WIKI_URL
+
+    def test_large_file_returns_202_with_task_id(self, client):
+        _set_oauth_session(client)
+        mock_task = MagicMock()
+        mock_task.id = "async-task-id-abc"
+        with patch("app.download_image", return_value="file.jpg"), \
+             patch("app.authenticated_session", return_value=MagicMock()), \
+             patch("app.os.path.getsize", return_value=60 * 1024 * 1024), \
+             patch("app.upload_image_task") as mock_upload_task:
+            mock_upload_task.delay.return_value = mock_task
+            resp = client.post("/api/upload", json=VALID_UPLOAD_BODY)
+
+        assert resp.status_code == 202
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["data"]["task_id"] == "async-task-id-abc"
+
+
+# =============================================================================
+# GET /api/preference
+# =============================================================================
+
+class TestPreferenceGet:
+    """Unauthenticated GET returns default project/language values."""
+
+    def test_unauthenticated_returns_defaults(self, client):
+        MW_OAUTH.get_current_user.return_value = None
+        resp = client.get("/api/preference")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["data"]["project"] == "wikipedia"
+        assert data["data"]["lang"] == "en"
+        assert data["data"]["skip_upload_selection"] is False
+
+
+# =============================================================================
+# POST /api/preference
+# =============================================================================
+
+class TestPreferencePost:
+    """Validation, auth enforcement, DB save and update."""
+
+    def test_missing_project_returns_400(self, client):
+        resp = client.post("/api/preference", json={"lang": "fr"})
+        assert resp.status_code == 400
+        assert resp.get_json()["success"] is False
+
+    def test_missing_lang_returns_400(self, client):
+        resp = client.post("/api/preference", json={"project": "wikipedia"})
+        assert resp.status_code == 400
+
+    def test_empty_body_returns_400(self, client):
+        resp = client.post("/api/preference", json={})
+        assert resp.status_code == 400
+
+    def test_unauthenticated_returns_401(self, client):
+        MW_OAUTH.get_current_user.return_value = None
+        resp = client.post("/api/preference", json={"project": "wikipedia", "lang": "fr"})
+        assert resp.status_code == 401
+        assert resp.get_json()["error_details"]["code"] == "AUTHENTICATION_ERROR"
+
+    def test_authenticated_save_returns_200(self, client):
+        MW_OAUTH.get_current_user.return_value = "pref_user1"
+        resp = client.post(
+            "/api/preference",
+            json={"project": "commons", "lang": "de", "skip_upload_selection": True},
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["success"] is True
+
+    def test_second_post_updates_existing_user(self, client):
+        # Same user, different preferences — should UPDATE not INSERT a second row
+        MW_OAUTH.get_current_user.return_value = "pref_user1"
+        resp = client.post(
+            "/api/preference",
+            json={"project": "wiktionary", "lang": "es", "skip_upload_selection": False},
+        )
+        assert resp.status_code == 200
+
+    def test_get_reflects_saved_preferences(self, client):
+        # Save then read back — values must match what was saved
+        MW_OAUTH.get_current_user.return_value = "pref_user2"
+        client.post(
+            "/api/preference",
+            json={"project": "wikibooks", "lang": "it", "skip_upload_selection": False},
+        )
+        resp = client.get("/api/preference")
+        data = resp.get_json()
+        assert data["data"]["project"] == "wikibooks"
+        assert data["data"]["lang"] == "it"
+
+
+# =============================================================================
+# GET /api/user_language
+# =============================================================================
+
+class TestUserLanguageGet:
+    """Unauthenticated GET returns 'en' as the default language."""
+
+    def test_unauthenticated_returns_en(self, client):
+        MW_OAUTH.get_current_user.return_value = None
+        resp = client.get("/api/user_language")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["data"]["user_language"] == "en"
+
+
+# =============================================================================
+# POST /api/user_language
+# =============================================================================
+
+class TestUserLanguagePost:
+    """Validation, auth enforcement, and DB persistence."""
+
+    def test_missing_user_language_returns_400(self, client):
+        resp = client.post("/api/user_language", json={})
+        assert resp.status_code == 400
+        assert resp.get_json()["error_details"]["code"] == "VALIDATION_ERROR"
+
+    def test_unauthenticated_returns_401(self, client):
+        MW_OAUTH.get_current_user.return_value = None
+        resp = client.post("/api/user_language", json={"user_language": "fr"})
+        assert resp.status_code == 401
+
+    def test_authenticated_save_returns_200(self, client):
+        MW_OAUTH.get_current_user.return_value = "lang_user1"
+        resp = client.post("/api/user_language", json={"user_language": "ja"})
+        assert resp.status_code == 200
+        assert resp.get_json()["success"] is True
+
+    def test_get_reflects_saved_language(self, client):
+        MW_OAUTH.get_current_user.return_value = "lang_user1"
+        client.post("/api/user_language", json={"user_language": "ko"})
+        resp = client.get("/api/user_language")
+        data = resp.get_json()
+        assert data["data"]["user_language"] == "ko"
+
+
+# =============================================================================
+# GET /api/get_wikitext
+# =============================================================================
+
+class TestGetWikitext:
+    """Wikitext endpoint — missing params, success, and timeout paths."""
+
+    def test_no_params_returns_empty_wikitext(self, client):
+        resp = client.get("/api/get_wikitext")
+        assert resp.status_code == 200
+        assert resp.get_json()["data"]["wikitext"] == ""
+
+    def test_partial_params_returns_empty_wikitext(self, client):
+        resp = client.get("/api/get_wikitext?src_lang=en&src_project=wikipedia")
+        assert resp.status_code == 200
+        assert resp.get_json()["data"]["wikitext"] == ""
+
+    def test_all_params_returns_localized_wikitext(self, client):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {
+            "query": {
+                "pages": [{
+                    "revisions": [{"slots": {"main": {"content": "== raw =="}}}]
+                }]
+            }
+        }
+        with patch("app.log_timed_api_call", _mock_timed), \
+             patch("app.requests.get", return_value=mock_resp), \
+             patch("app.get_localized_wikitext", return_value="== localized =="):
+            resp = client.get(
+                "/api/get_wikitext"
+                "?src_lang=en&src_project=wikipedia"
+                "&src_filename=File%3AExample.jpg&tr_lang=fr"
+            )
+        assert resp.status_code == 200
+        assert resp.get_json()["data"]["wikitext"] == "== localized =="
+
+    def test_no_revisions_in_response_returns_empty(self, client):
+        # Page exists but has no revision history
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {"query": {"pages": [{}]}}
+        with patch("app.log_timed_api_call", _mock_timed), \
+             patch("app.requests.get", return_value=mock_resp):
+            resp = client.get(
+                "/api/get_wikitext"
+                "?src_lang=en&src_project=wikipedia"
+                "&src_filename=File%3AExample.jpg&tr_lang=fr"
+            )
+        assert resp.status_code == 200
+        assert resp.get_json()["data"]["wikitext"] == ""
+
+    def test_api_timeout_returns_502(self, client):
+        import requests as req
+        with patch("app.log_timed_api_call", _mock_timed), \
+             patch("app.requests.get", side_effect=req.exceptions.Timeout()):
+            resp = client.get(
+                "/api/get_wikitext"
+                "?src_lang=en&src_project=wikipedia"
+                "&src_filename=File%3AExample.jpg&tr_lang=fr"
+            )
+        assert resp.status_code == 502
+
+    def test_api_connection_error_returns_502(self, client):
+        import requests as req
+        with patch("app.log_timed_api_call", _mock_timed), \
+             patch("app.requests.get", side_effect=req.exceptions.ConnectionError("refused")):
+            resp = client.get(
+                "/api/get_wikitext"
+                "?src_lang=en&src_project=wikipedia"
+                "&src_filename=File%3AExample.jpg&tr_lang=fr"
+            )
+        assert resp.status_code == 502
+
+
+# =============================================================================
+# POST /api/edit_page
+# =============================================================================
+
+class TestEditPageValidation:
+    """Input validation and auth check before any network call is made."""
+
+    def test_missing_target_url_returns_400(self, client):
+        resp = client.post("/api/edit_page", json={"content": "hello"})
+        assert resp.status_code == 400
+        assert resp.get_json()["error_details"]["code"] == "VALIDATION_ERROR"
+
+    def test_missing_content_returns_400(self, client):
+        resp = client.post("/api/edit_page", json={"targetUrl": VALID_WIKI_URL})
+        assert resp.status_code == 400
+        assert resp.get_json()["error_details"]["code"] == "VALIDATION_ERROR"
+
+    def test_non_wiki_target_url_returns_400(self, client):
+        resp = client.post(
+            "/api/edit_page",
+            json={"targetUrl": "https://notawiki.com/page", "content": "hello"},
+        )
+        assert resp.status_code == 400
+
+    def test_unauthenticated_returns_401(self, client):
+        with patch("app.authenticated_session", return_value=None):
+            resp = client.post(
+                "/api/edit_page",
+                json={"targetUrl": VALID_WIKI_URL, "content": "hello"},
+            )
+        assert resp.status_code == 401
+        assert resp.get_json()["error_details"]["code"] == "AUTHENTICATION_ERROR"
+
+    def test_csrf_timeout_returns_502(self, client):
+        import requests as req
+        with patch("app.authenticated_session", return_value=MagicMock()), \
+             patch("app.log_timed_api_call", _mock_timed), \
+             patch("app.requests.get", side_effect=req.exceptions.Timeout()):
+            resp = client.post(
+                "/api/edit_page",
+                json={"targetUrl": VALID_WIKI_URL, "content": "hello"},
+            )
+        assert resp.status_code == 502
+
+
+class TestEditPageSuccess:
+    """Successful edit — CSRF token fetched and edit POST accepted."""
+
+    def test_valid_edit_returns_200(self, client):
+        csrf_resp = MagicMock()
+        csrf_resp.status_code = 200
+        csrf_resp.raise_for_status.return_value = None
+        csrf_resp.json.return_value = {"query": {"tokens": {"csrftoken": "validtoken"}}}
+
+        post_resp = MagicMock()
+        post_resp.status_code = 200
+        post_resp.raise_for_status.return_value = None
+
+        with patch("app.authenticated_session", return_value=MagicMock()), \
+             patch("app.log_timed_api_call", _mock_timed), \
+             patch("app.requests.get", return_value=csrf_resp), \
+             patch("app.requests.post", return_value=post_resp):
+            resp = client.post(
+                "/api/edit_page",
+                json={"targetUrl": VALID_WIKI_URL, "content": "hello"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.get_json()["success"] is True
+
+    def test_anon_csrf_token_returns_401(self, client):
+        # MW returns "+\" when OAuth session is not recognized — treat as auth failure
+        csrf_resp = MagicMock()
+        csrf_resp.status_code = 200
+        csrf_resp.raise_for_status.return_value = None
+        csrf_resp.json.return_value = {"query": {"tokens": {"csrftoken": "+\\"}}}
+
+        with patch("app.authenticated_session", return_value=MagicMock()), \
+             patch("app.log_timed_api_call", _mock_timed), \
+             patch("app.requests.get", return_value=csrf_resp):
+            resp = client.post(
+                "/api/edit_page",
+                json={"targetUrl": VALID_WIKI_URL, "content": "hello"},
+            )
+
+        assert resp.status_code == 401
+
+
+# =============================================================================
+# GET /api/user
+# =============================================================================
+
+class TestUserEndpoint:
+    """GET /api/user returns `logged` boolean and `username`."""
+
+    def test_logged_out_returns_false_and_none(self, client):
+        MW_OAUTH.get_current_user.return_value = None
+        resp = client.get("/api/user")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["data"]["logged"] is False
+        assert data["data"]["username"] is None
+
+    def test_logged_in_returns_true_and_username(self, client):
+        MW_OAUTH.get_current_user.return_value = "WikiUser123"
+        resp = client.get("/api/user")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["data"]["logged"] is True
+        assert data["data"]["username"] == "WikiUser123"
+
+
+# =============================================================================
+# GET /api/task_status/<task_id>
+# =============================================================================
+
+class TestTaskStatus:
+    """GET /api/task_status/<id> reflects the Celery task state."""
+
+    def test_pending_task_returns_correct_fields(self, client):
+        mock_result = MagicMock()
+        mock_result.status = "PENDING"
+        mock_result.successful.return_value = False
+        mock_result.failed.return_value = False
+        mock_result.result = None
+
+        with patch("app.AsyncResult", return_value=mock_result):
+            resp = client.get("/api/task_status/pending-task-id")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["data"]["task_id"] == "pending-task-id"
+        assert data["data"]["status"] == "PENDING"
+        assert data["data"]["result"] is None
+
+    def test_successful_task_includes_result(self, client):
+        mock_result = MagicMock()
+        mock_result.status = "SUCCESS"
+        mock_result.successful.return_value = True
+        mock_result.failed.return_value = False
+        mock_result.result = {
+            "file_link": "https://upload.wikimedia.org/test.jpg",
+            "wikipage_url": "https://commons.wikimedia.org/wiki/File:Test.jpg",
+        }
+
+        with patch("app.AsyncResult", return_value=mock_result):
+            resp = client.get("/api/task_status/success-task-id")
+
+        data = resp.get_json()
+        assert data["data"]["status"] == "SUCCESS"
+        assert data["data"]["result"]["file_link"] == "https://upload.wikimedia.org/test.jpg"
+
+    def test_failed_task_includes_error_field(self, client):
+        mock_result = MagicMock()
+        mock_result.status = "FAILURE"
+        mock_result.successful.return_value = False
+        mock_result.failed.return_value = True
+        mock_result.result = Exception("upload failed")
+
+        with patch("app.AsyncResult", return_value=mock_result):
+            resp = client.get("/api/task_status/failed-task-id")
+
+        data = resp.get_json()
+        assert data["data"]["status"] == "FAILURE"
+        assert "error" in data["data"]
+        assert "upload failed" in data["data"]["error"]

--- a/tests/tasks_test.py
+++ b/tests/tasks_test.py
@@ -1,0 +1,415 @@
+"""
+Tests for upload_image_task() in tasks.py
+
+
+The mock self needs to have:
+  - self.request.id       → fake task ID (used in log messages)
+  - self.request.retries  → how many retries have happened so far
+  - self.max_retries      → max allowed retries (3 in the real task)
+  - self.update_state()   → no-op, we don't care about Celery state in tests
+  - self.retry(exc=e)     → raises celery.exceptions.Retry (simulates scheduling a retry)
+
+WHY TASKS NEVER RAISE
+======================
+Unlike utils.py, the task always returns a dict — it never raises.
+The only exception is Retry, which Celery uses internally and must be re-raised.
+So every test checks the RETURN VALUE, not raised exceptions.
+(Except retry tests, which check that Retry is raised.)
+
+HOW TO RUN
+==========
+  pytest tests/tasks_test.py -v
+"""
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from unittest.mock import patch, MagicMock, mock_open
+from contextlib import contextmanager
+from celery.exceptions import Retry
+import requests as req
+
+from tasks import upload_image_task
+
+
+# ─── mock for log_timed_api_call ──────────────────────────────────────────────
+# tasks.py does:  with log_timed_api_call(logger, endpoint, method) as ctx:
+#                     ctx["status_code"] = ...
+# The real one yields a dict — our fake does the same so ctx["status_code"] works.
+
+@contextmanager
+def _mock_timed_api_call(logger, endpoint, method):
+    yield {}
+
+
+# ─── mock Celery self ─────────────────────────────────────────────────────────
+
+def _make_self(retries=0, max_retries=3):
+    """
+    Builds a fake Celery task instance.
+    retries=0 means this is the first attempt (no retries yet).
+    Setting retries=max_retries simulates exhausted retries.
+    """
+    mock_self = MagicMock()
+    mock_self.request.id = "test-task-id-123"
+    mock_self.request.retries = retries
+    mock_self.max_retries = max_retries
+    # self.retry(exc=e) raises Retry in the real Celery — simulate that here
+    mock_self.retry.side_effect = Retry()
+    return mock_self
+
+
+# ─── shared test data ─────────────────────────────────────────────────────────
+
+VALID_OAUTH = {
+    "consumer_key": "ck",
+    "consumer_secret": "cs",
+    "key": "k",
+    "secret": "s"
+}
+
+TR_ENDPOINT = "https://commons.wikimedia.org/w/api.php"
+FILE_PATH = "temp_images/test.jpg"
+TR_FILENAME = "TestFile"
+SRC_FILEEXT = "jpg"
+
+
+# ─── fake API response builders ───────────────────────────────────────────────
+
+def _csrf_response(token="validtoken123"):
+    m = MagicMock()
+    m.status_code = 200
+    m.json.return_value = {"query": {"tokens": {"csrftoken": token}}}
+    return m
+
+
+def _upload_ok_response():
+    m = MagicMock()
+    m.status_code = 200
+    m.json.return_value = {
+        "upload": {
+            "result": "Success",
+            "imageinfo": {
+                "url": "https://upload.wikimedia.org/wikipedia/commons/a/a9/Test.jpg",
+                "descriptionurl": "https://commons.wikimedia.org/wiki/File:TestFile.jpg"
+            }
+        }
+    }
+    return m
+
+
+def _upload_fail_response(error_info="File is corrupt"):
+    m = MagicMock()
+    m.status_code = 200
+    m.json.return_value = {
+        "upload": {
+            "result": "Failure",
+            "error": {"info": error_info}
+        }
+    }
+    return m
+
+
+def _upload_no_imageinfo_response():
+    m = MagicMock()
+    m.status_code = 200
+    m.json.return_value = {"upload": {"result": "Success"}}
+    return m
+
+
+# =============================================================================
+# SUCCESS
+# =============================================================================
+
+class TestSuccess:
+    """Full happy path — CSRF fetched, file uploaded, result validated."""
+
+    @patch("tasks.log_timed_api_call", _mock_timed_api_call)
+    @patch("tasks.os.path.getsize", return_value=1024)
+    @patch("tasks.os.path.exists", return_value=True)
+    @patch("builtins.open", mock_open(read_data=b"fake-bytes"))
+    @patch("tasks.requests.post")
+    @patch("tasks.requests.get")
+    @patch("tasks.requests_oauthlib.OAuth1")
+    def test_returns_success_true(self, mock_oauth, mock_get, mock_post, mock_exists, mock_size):
+        mock_get.return_value = _csrf_response()
+        mock_post.return_value = _upload_ok_response()
+
+        result = upload_image_task(_make_self(), FILE_PATH, TR_FILENAME, SRC_FILEEXT, TR_ENDPOINT, VALID_OAUTH)
+
+        assert result["success"] is True
+
+    @patch("tasks.log_timed_api_call", _mock_timed_api_call)
+    @patch("tasks.os.path.getsize", return_value=1024)
+    @patch("tasks.os.path.exists", return_value=True)
+    @patch("builtins.open", mock_open(read_data=b"fake-bytes"))
+    @patch("tasks.requests.post")
+    @patch("tasks.requests.get")
+    @patch("tasks.requests_oauthlib.OAuth1")
+    def test_returns_correct_urls(self, mock_oauth, mock_get, mock_post, mock_exists, mock_size):
+        mock_get.return_value = _csrf_response()
+        mock_post.return_value = _upload_ok_response()
+
+        result = upload_image_task(_make_self(), FILE_PATH, TR_FILENAME, SRC_FILEEXT, TR_ENDPOINT, VALID_OAUTH)
+
+        assert result["wikipage_url"] == "https://commons.wikimedia.org/wiki/File:TestFile.jpg"
+        assert result["file_link"] == "https://upload.wikimedia.org/wikipedia/commons/a/a9/Test.jpg"
+
+    @patch("tasks.log_timed_api_call", _mock_timed_api_call)
+    @patch("tasks.os.path.getsize", return_value=1024)
+    @patch("tasks.os.path.exists", return_value=True)
+    @patch("builtins.open", mock_open(read_data=b"fake-bytes"))
+    @patch("tasks.requests.post")
+    @patch("tasks.requests.get")
+    @patch("tasks.requests_oauthlib.OAuth1")
+    def test_csrf_token_sent_in_upload(self, mock_oauth, mock_get, mock_post, mock_exists, mock_size):
+        # The CSRF token from the GET must appear in the POST data
+        mock_get.return_value = _csrf_response("mytoken999")
+        mock_post.return_value = _upload_ok_response()
+
+        upload_image_task(_make_self(), FILE_PATH, TR_FILENAME, SRC_FILEEXT, TR_ENDPOINT, VALID_OAUTH)
+
+        post_data = mock_post.call_args[1]["data"]
+        assert post_data["token"] == "mytoken999"
+
+
+# =============================================================================
+# MISSING / BAD OAUTH CREDENTIALS
+# =============================================================================
+
+class TestOAuthCredentials:
+    """Task returns failure immediately when credentials are wrong — no network calls made."""
+
+    def test_missing_all_keys_returns_failure(self):
+        result = upload_image_task(_make_self(), FILE_PATH, TR_FILENAME, SRC_FILEEXT, TR_ENDPOINT, {})
+
+        assert result["success"] is False
+        assert "Missing OAuth credentials" in result["errors"][0]
+
+    def test_missing_single_key_returns_failure(self):
+        incomplete = {k: v for k, v in VALID_OAUTH.items() if k != "secret"}
+
+        result = upload_image_task(_make_self(), FILE_PATH, TR_FILENAME, SRC_FILEEXT, TR_ENDPOINT, incomplete)
+
+        assert result["success"] is False
+        assert "secret" in result["errors"][0]
+
+    @patch("tasks.requests_oauthlib.OAuth1")
+    def test_oauth_session_creation_failure_returns_failure(self, mock_oauth):
+        mock_oauth.side_effect = Exception("OAuth library error")
+
+        result = upload_image_task(_make_self(), FILE_PATH, TR_FILENAME, SRC_FILEEXT, TR_ENDPOINT, VALID_OAUTH)
+
+        assert result["success"] is False
+        assert "Failed to create OAuth session" in result["errors"][0]
+
+
+# =============================================================================
+# CSRF TOKEN ERRORS
+# =============================================================================
+
+class TestCSRFErrors:
+    """Failures when fetching or validating the CSRF token."""
+
+    @patch("tasks.log_timed_api_call", _mock_timed_api_call)
+    @patch("tasks.requests.get")
+    @patch("tasks.requests_oauthlib.OAuth1")
+    def test_anon_csrf_token_returns_failure_no_retry(self, mock_oauth, mock_get):
+        # "+\" means OAuth session not recognized — should NOT retry, return immediately
+        mock_get.return_value = _csrf_response(token="+\\")
+        mock_self = _make_self(retries=0)
+
+        result = upload_image_task(mock_self, FILE_PATH, TR_FILENAME, SRC_FILEEXT, TR_ENDPOINT, VALID_OAUTH)
+
+        assert result["success"] is False
+        assert "CSRF token" in result["errors"][0]
+        # retry must NOT have been called — retrying with an expired token is pointless
+        mock_self.retry.assert_not_called()
+
+    @patch("tasks.log_timed_api_call", _mock_timed_api_call)
+    @patch("tasks.requests.get")
+    @patch("tasks.requests_oauthlib.OAuth1")
+    def test_csrf_timeout_triggers_retry_when_retries_remain(self, mock_oauth, mock_get):
+        mock_get.side_effect = req.exceptions.Timeout()
+        mock_self = _make_self(retries=0, max_retries=3)
+
+        with pytest.raises(Retry):
+            upload_image_task(mock_self, FILE_PATH, TR_FILENAME, SRC_FILEEXT, TR_ENDPOINT, VALID_OAUTH)
+
+        mock_self.retry.assert_called_once()
+
+    @patch("tasks.log_timed_api_call", _mock_timed_api_call)
+    @patch("tasks.requests.get")
+    @patch("tasks.requests_oauthlib.OAuth1")
+    def test_csrf_timeout_returns_failure_when_retries_exhausted(self, mock_oauth, mock_get):
+        mock_get.side_effect = req.exceptions.Timeout()
+        # retries == max_retries means no more retries left
+        mock_self = _make_self(retries=3, max_retries=3)
+
+        result = upload_image_task(mock_self, FILE_PATH, TR_FILENAME, SRC_FILEEXT, TR_ENDPOINT, VALID_OAUTH)
+
+        assert result["success"] is False
+        assert "Timeout" in result["errors"][0]
+
+    @patch("tasks.log_timed_api_call", _mock_timed_api_call)
+    @patch("tasks.requests.get")
+    @patch("tasks.requests_oauthlib.OAuth1")
+    def test_csrf_request_error_triggers_retry_when_retries_remain(self, mock_oauth, mock_get):
+        mock_get.side_effect = req.exceptions.ConnectionError("refused")
+        mock_self = _make_self(retries=0)
+
+        with pytest.raises(Retry):
+            upload_image_task(mock_self, FILE_PATH, TR_FILENAME, SRC_FILEEXT, TR_ENDPOINT, VALID_OAUTH)
+
+    @patch("tasks.log_timed_api_call", _mock_timed_api_call)
+    @patch("tasks.requests.get")
+    @patch("tasks.requests_oauthlib.OAuth1")
+    def test_csrf_missing_key_returns_failure_no_retry(self, mock_oauth, mock_get):
+        # Response is valid JSON but missing expected keys — not a network error, don't retry
+        m = MagicMock()
+        m.status_code = 200
+        m.json.return_value = {"query": {}}  # no "tokens" key
+        mock_get.return_value = m
+        mock_self = _make_self(retries=0)
+
+        result = upload_image_task(mock_self, FILE_PATH, TR_FILENAME, SRC_FILEEXT, TR_ENDPOINT, VALID_OAUTH)
+
+        assert result["success"] is False
+        assert "CSRF" in result["errors"][0]
+        mock_self.retry.assert_not_called()
+
+
+# =============================================================================
+# FILE ERRORS
+# =============================================================================
+
+class TestFileErrors:
+    """Failures when the local file can't be found or read before upload."""
+
+    @patch("tasks.log_timed_api_call", _mock_timed_api_call)
+    @patch("tasks.os.path.exists", return_value=False)
+    @patch("tasks.requests.get")
+    @patch("tasks.requests_oauthlib.OAuth1")
+    def test_file_not_found_returns_failure(self, mock_oauth, mock_get, mock_exists):
+        mock_get.return_value = _csrf_response()
+
+        result = upload_image_task(_make_self(), FILE_PATH, TR_FILENAME, SRC_FILEEXT, TR_ENDPOINT, VALID_OAUTH)
+
+        assert result["success"] is False
+        assert "not found" in result["errors"][0]
+
+    @patch("tasks.log_timed_api_call", _mock_timed_api_call)
+    @patch("tasks.os.path.getsize", return_value=1024)
+    @patch("tasks.os.path.exists", return_value=True)
+    @patch("builtins.open")
+    @patch("tasks.requests.get")
+    @patch("tasks.requests_oauthlib.OAuth1")
+    def test_oserror_reading_file_returns_failure(self, mock_oauth, mock_get, mock_open_fn, mock_exists, mock_size):
+        mock_get.return_value = _csrf_response()
+        mock_open_fn.side_effect = OSError("Permission denied")
+
+        result = upload_image_task(_make_self(), FILE_PATH, TR_FILENAME, SRC_FILEEXT, TR_ENDPOINT, VALID_OAUTH)
+
+        assert result["success"] is False
+        assert "Could not read file" in result["errors"][0]
+
+
+# =============================================================================
+# UPLOAD NETWORK ERRORS
+# =============================================================================
+
+class TestUploadNetworkErrors:
+    """Network failures during the actual file upload POST."""
+
+    @patch("tasks.log_timed_api_call", _mock_timed_api_call)
+    @patch("tasks.os.path.getsize", return_value=1024)
+    @patch("tasks.os.path.exists", return_value=True)
+    @patch("builtins.open", mock_open(read_data=b"fake-bytes"))
+    @patch("tasks.requests.post")
+    @patch("tasks.requests.get")
+    @patch("tasks.requests_oauthlib.OAuth1")
+    def test_upload_timeout_triggers_retry_when_retries_remain(self, mock_oauth, mock_get, mock_post, mock_exists, mock_size):
+        mock_get.return_value = _csrf_response()
+        mock_post.side_effect = req.exceptions.Timeout()
+        mock_self = _make_self(retries=0)
+
+        with pytest.raises(Retry):
+            upload_image_task(mock_self, FILE_PATH, TR_FILENAME, SRC_FILEEXT, TR_ENDPOINT, VALID_OAUTH)
+
+        mock_self.retry.assert_called_once()
+
+    @patch("tasks.log_timed_api_call", _mock_timed_api_call)
+    @patch("tasks.os.path.getsize", return_value=1024)
+    @patch("tasks.os.path.exists", return_value=True)
+    @patch("builtins.open", mock_open(read_data=b"fake-bytes"))
+    @patch("tasks.requests.post")
+    @patch("tasks.requests.get")
+    @patch("tasks.requests_oauthlib.OAuth1")
+    def test_upload_timeout_returns_failure_when_retries_exhausted(self, mock_oauth, mock_get, mock_post, mock_exists, mock_size):
+        mock_get.return_value = _csrf_response()
+        mock_post.side_effect = req.exceptions.Timeout()
+        mock_self = _make_self(retries=3, max_retries=3)
+
+        result = upload_image_task(mock_self, FILE_PATH, TR_FILENAME, SRC_FILEEXT, TR_ENDPOINT, VALID_OAUTH)
+
+        assert result["success"] is False
+        assert "Timeout" in result["errors"][0]
+
+    @patch("tasks.log_timed_api_call", _mock_timed_api_call)
+    @patch("tasks.os.path.getsize", return_value=1024)
+    @patch("tasks.os.path.exists", return_value=True)
+    @patch("builtins.open", mock_open(read_data=b"fake-bytes"))
+    @patch("tasks.requests.post")
+    @patch("tasks.requests.get")
+    @patch("tasks.requests_oauthlib.OAuth1")
+    def test_upload_request_error_triggers_retry(self, mock_oauth, mock_get, mock_post, mock_exists, mock_size):
+        mock_get.return_value = _csrf_response()
+        mock_post.side_effect = req.exceptions.ConnectionError("network error")
+        mock_self = _make_self(retries=0)
+
+        with pytest.raises(Retry):
+            upload_image_task(mock_self, FILE_PATH, TR_FILENAME, SRC_FILEEXT, TR_ENDPOINT, VALID_OAUTH)
+
+
+# =============================================================================
+# UPLOAD RESULT VALIDATION
+# =============================================================================
+
+class TestUploadResultValidation:
+    """The POST succeeded but the wiki rejected the upload or returned unexpected data."""
+
+    @patch("tasks.log_timed_api_call", _mock_timed_api_call)
+    @patch("tasks.os.path.getsize", return_value=1024)
+    @patch("tasks.os.path.exists", return_value=True)
+    @patch("builtins.open", mock_open(read_data=b"fake-bytes"))
+    @patch("tasks.requests.post")
+    @patch("tasks.requests.get")
+    @patch("tasks.requests_oauthlib.OAuth1")
+    def test_upload_result_failure_returns_failure(self, mock_oauth, mock_get, mock_post, mock_exists, mock_size):
+        mock_get.return_value = _csrf_response()
+        mock_post.return_value = _upload_fail_response("File is corrupt")
+
+        result = upload_image_task(_make_self(), FILE_PATH, TR_FILENAME, SRC_FILEEXT, TR_ENDPOINT, VALID_OAUTH)
+
+        assert result["success"] is False
+        assert "Upload failed" in result["errors"][0]
+        assert "File is corrupt" in result["errors"][0]
+
+    @patch("tasks.log_timed_api_call", _mock_timed_api_call)
+    @patch("tasks.os.path.getsize", return_value=1024)
+    @patch("tasks.os.path.exists", return_value=True)
+    @patch("builtins.open", mock_open(read_data=b"fake-bytes"))
+    @patch("tasks.requests.post")
+    @patch("tasks.requests.get")
+    @patch("tasks.requests_oauthlib.OAuth1")
+    def test_upload_missing_imageinfo_returns_failure(self, mock_oauth, mock_get, mock_post, mock_exists, mock_size):
+        # Wiki says "Success" but no imageinfo in response
+        mock_get.return_value = _csrf_response()
+        mock_post.return_value = _upload_no_imageinfo_response()
+
+        result = upload_image_task(_make_self(), FILE_PATH, TR_FILENAME, SRC_FILEEXT, TR_ENDPOINT, VALID_OAUTH)
+
+        assert result["success"] is False
+        assert "imageinfo" in result["errors"][0]

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,0 +1,717 @@
+"""
+Tests for download_image(), process_upload(), and get_localized_wikitext() in utils.py
+
+WHY NO REAL NETWORK CALLS
+==========================
+These functions hit Wikipedia's API. Running tests against the real API is a bad idea —
+it's slow, it breaks when Wikipedia is down, and it means your test results depend on
+whether your internet connection is having a bad day. Not great for CI.
+
+So we use unittest.mock to swap out requests.get and requests.post with fakes that
+return whatever JSON we tell them to. The function has no idea it's talking to a fake —
+it just sees a response object and processes it the same way it would in production.
+
+HOW TO RUN
+==========
+  pytest tests/utils_test.py -v
+
+
+WHAT THESE TESTS ACTUALLY PROVE
+================================
+If all pass, you know:
+  - download_image() works end to end (finds URL, downloads file, saves it, returns filename)
+  - timeouts and connection errors raise the RIGHT exception type, not None or a generic Exception
+  - metadata failure and download failure raise DIFFERENT exceptions (they're different problems)
+  - process_upload() catches the +\\ CSRF token before the upload even starts
+  - get_localized_wikitext() keeps going if one article lookup fails — it doesn't abort everything
+  - the iilocalonly param is being sent (remove it and you'll see why Commons files break)
+"""
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from unittest.mock import patch, MagicMock, mock_open, call
+from contextlib import contextmanager
+
+from utils import download_image, process_upload, get_localized_wikitext
+from exceptions import WikiAPIError, FileOperationError, ResourceNotFoundError, AuthenticationError
+import requests as req
+
+
+# ─── mock for log_timed_api_call ─────────────────────────────────────────────
+# The real log_timed_api_call does `yield` (no value), but utils.py uses
+#   `with log_timed_api_call(...) as context:` then `context["status_code"] = ...`
+# That would crash with TypeError because context would be None.
+# Our fake yields a plain dict so that line works fine.
+
+@contextmanager
+def _mock_timed_api_call(logger, endpoint, method):
+    yield {}
+
+
+# ─── fake API responses ───────────────────────────────────────────────────────
+
+# What Wikipedia returns when the image EXISTS and has a local URL
+FOUND_RESPONSE = {
+    "batchcomplete": "",
+    "query": {
+        "pages": {
+            "12345": {
+                "ns": 6,
+                "title": "File:Example.jpg",
+                "imageinfo": [
+                    {"url": "https://upload.wikimedia.org/wikipedia/commons/a/a9/Example.jpg"}
+                ]
+            }
+        }
+    }
+}
+
+# What Wikipedia returns when the file is missing (no imageinfo key)
+MISSING_RESPONSE = {
+    "batchcomplete": "",
+    "query": {
+        "pages": {
+            "-1": {
+                "ns": 6,
+                "title": "File:Missing.jpg",
+                "missing": ""
+            }
+        }
+    }
+}
+
+# What Wikipedia returns when iilocalonly blocks a Commons-hosted file
+# (page exists but imageinfo is absent because the file lives on Commons)
+COMMONS_FILE_RESPONSE = {
+    "batchcomplete": "",
+    "query": {
+        "pages": {
+            "99999": {
+                "ns": 6,
+                "title": "File:Commons_only.jpg"
+                # no "imageinfo" key — blocked by iilocalonly
+            }
+        }
+    }
+}
+
+# Empty pages dict — API gave us nothing
+EMPTY_PAGES_RESPONSE = {
+    "batchcomplete": "",
+    "query": {"pages": {}}
+}
+
+
+# ─── helpers to build mock response objects ───────────────────────────────────
+
+def _meta_response(data):
+    """Fake first requests.get call (wiki API metadata)."""
+    m = MagicMock()
+    m.status_code = 200
+    m.json.return_value = data
+    return m
+
+
+def _image_response():
+    """Fake second requests.get call (actual image bytes)."""
+    m = MagicMock()
+    m.status_code = 200
+    m.headers = {"Content-Type": "image/jpeg"}
+    m.content = b"fake-image-bytes"
+    return m
+
+
+# ─── SUCCESS TESTS ────────────────────────────────────────────────────────────
+
+class TestSuccess:
+    """The image exists and downloads without errors."""
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.os.makedirs")
+    @patch("builtins.open", mock_open())
+    @patch("utils.requests.get")
+    def test_returns_a_filename_string(self, mock_get, mock_makedirs):
+        # ARRANGE: first call = metadata, second call = image bytes
+        mock_get.side_effect = [_meta_response(FOUND_RESPONSE), _image_response()]
+
+        # ACT
+        result = download_image("wikipedia", "en", "File:Example.jpg")
+
+        # ASSERT: we get a string back (the saved filename)
+        assert isinstance(result, str)
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.os.makedirs")
+    @patch("builtins.open", mock_open())
+    @patch("utils.requests.get")
+    def test_filename_has_jpeg_extension(self, mock_get, mock_makedirs):
+        mock_get.side_effect = [_meta_response(FOUND_RESPONSE), _image_response()]
+        result = download_image("wikipedia", "en", "File:Example.jpg")
+        # Content-Type was image/jpeg so extension should be .jpeg
+        assert result.endswith(".jpeg")
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.os.makedirs")
+    @patch("builtins.open", mock_open())
+    @patch("utils.requests.get")
+    def test_makes_exactly_two_http_requests(self, mock_get, mock_makedirs):
+        mock_get.side_effect = [_meta_response(FOUND_RESPONSE), _image_response()]
+        download_image("wikipedia", "en", "File:Example.jpg")
+        # One call for metadata, one for the image file
+        assert mock_get.call_count == 2
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.os.makedirs")
+    @patch("builtins.open", mock_open())
+    @patch("utils.requests.get")
+    def test_creates_temp_images_directory(self, mock_get, mock_makedirs):
+        mock_get.side_effect = [_meta_response(FOUND_RESPONSE), _image_response()]
+        download_image("wikipedia", "en", "File:Example.jpg")
+        mock_makedirs.assert_called_once_with("temp_images", exist_ok=True)
+
+
+# ─── ENDPOINT CONSTRUCTION TESTS ─────────────────────────────────────────────
+
+class TestEndpointConstruction:
+    """The API URL must be built correctly from the arguments."""
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.os.makedirs")
+    @patch("builtins.open", mock_open())
+    @patch("utils.requests.get")
+    def test_builds_correct_api_url(self, mock_get, mock_makedirs):
+        mock_get.side_effect = [_meta_response(FOUND_RESPONSE), _image_response()]
+        download_image("wikipedia", "fr", "File:Example.jpg")
+
+        first_call_kwargs = mock_get.call_args_list[0][1]
+        assert first_call_kwargs["url"] == "https://fr.wikipedia.org/w/api.php"
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.os.makedirs")
+    @patch("builtins.open", mock_open())
+    @patch("utils.requests.get")
+    def test_sends_iilocalonly_param(self, mock_get, mock_makedirs):
+        # This param is why Commons-hosted files return no imageinfo.
+        # Confirming it is sent lets you decide if removing it would help.
+        mock_get.side_effect = [_meta_response(FOUND_RESPONSE), _image_response()]
+        download_image("wikipedia", "en", "File:Example.jpg")
+
+        params = mock_get.call_args_list[0][1]["params"]
+        assert params["iilocalonly"] == 1
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.os.makedirs")
+    @patch("builtins.open", mock_open())
+    @patch("utils.requests.get")
+    def test_sends_filename_as_titles_param(self, mock_get, mock_makedirs):
+        mock_get.side_effect = [_meta_response(FOUND_RESPONSE), _image_response()]
+        download_image("wikipedia", "en", "File:Example.jpg")
+
+        params = mock_get.call_args_list[0][1]["params"]
+        assert params["titles"] == "File:Example.jpg"
+
+
+# ─── RESOURCE NOT FOUND TESTS ─────────────────────────────────────────────────
+
+class TestResourceNotFound:
+    """The file doesn't exist or imageinfo is absent → ResourceNotFoundError."""
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.requests.get")
+    def test_raises_when_file_is_missing(self, mock_get):
+        # Wikipedia returns the page but with "missing": "" and no imageinfo
+        mock_get.return_value = _meta_response(MISSING_RESPONSE)
+
+        with pytest.raises(ResourceNotFoundError) as exc:
+            download_image("wikipedia", "en", "File:Missing.jpg")
+
+        assert "Image not found" in str(exc.value)
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.requests.get")
+    def test_raises_when_commons_file_blocked_by_iilocalonly(self, mock_get):
+        # File exists but lives on Commons — iilocalonly hides imageinfo
+        mock_get.return_value = _meta_response(COMMONS_FILE_RESPONSE)
+
+        with pytest.raises(ResourceNotFoundError) as exc:
+            download_image("wikipedia", "en", "File:Commons_only.jpg")
+
+        assert "Image not found" in str(exc.value)
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.requests.get")
+    def test_raises_when_pages_is_empty(self, mock_get):
+        mock_get.return_value = _meta_response(EMPTY_PAGES_RESPONSE)
+
+        with pytest.raises(ResourceNotFoundError):
+            download_image("wikipedia", "en", "File:Example.jpg")
+
+
+# ─── NETWORK ERROR TESTS ──────────────────────────────────────────────────────
+
+class TestNetworkErrors:
+    """requests raises an exception → our code wraps it in the right exception."""
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.requests.get")
+    def test_metadata_timeout_raises_wiki_api_error(self, mock_get):
+        # The first GET (metadata) times out
+        mock_get.side_effect = req.exceptions.Timeout()
+
+        with pytest.raises(WikiAPIError) as exc:
+            download_image("wikipedia", "en", "File:Example.jpg")
+
+        assert "Timeout" in str(exc.value)
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.requests.get")
+    def test_metadata_connection_error_raises_wiki_api_error(self, mock_get):
+        mock_get.side_effect = req.exceptions.ConnectionError("refused")
+
+        with pytest.raises(WikiAPIError):
+            download_image("wikipedia", "en", "File:Example.jpg")
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.requests.get")
+    def test_image_download_timeout_raises_file_operation_error(self, mock_get):
+        # First GET succeeds, second (image download) times out
+        mock_get.side_effect = [
+            _meta_response(FOUND_RESPONSE),
+            req.exceptions.Timeout(),
+        ]
+
+        with pytest.raises(FileOperationError) as exc:
+            download_image("wikipedia", "en", "File:Example.jpg")
+
+        assert "Timeout" in str(exc.value)
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.requests.get")
+    def test_image_download_request_error_raises_file_operation_error(self, mock_get):
+        mock_get.side_effect = [
+            _meta_response(FOUND_RESPONSE),
+            req.exceptions.RequestException("network error"),
+        ]
+
+        with pytest.raises(FileOperationError):
+            download_image("wikipedia", "en", "File:Example.jpg")
+
+
+# ─── FILE WRITE ERROR TESTS ───────────────────────────────────────────────────
+
+class TestFileWriteErrors:
+    """Disk errors when saving the image → FileOperationError."""
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.os.makedirs")
+    @patch("builtins.open")
+    @patch("utils.requests.get")
+    def test_disk_full_raises_file_operation_error(self, mock_get, mock_open_fn, mock_makedirs):
+        mock_get.side_effect = [_meta_response(FOUND_RESPONSE), _image_response()]
+        mock_open_fn.side_effect = OSError("No space left on device")
+
+        with pytest.raises(FileOperationError) as exc:
+            download_image("wikipedia", "en", "File:Example.jpg")
+
+        assert "Failed to write" in str(exc.value)
+
+
+# =============================================================================
+# process_upload() TESTS
+# =============================================================================
+"""
+HOW PROCESS_UPLOAD WORKS
+========================
+1. GET the CSRF token from the target wiki API (authenticated)
+2. Check the token is not "+\\" (anon token — means OAuth session is invalid)
+3. Check the local file exists before even opening it
+4. POST the file to the upload API with the CSRF token
+5. Validate the response — must be "Success" and include "imageinfo"
+6. Return {"wikipage_url": ..., "file_link": ...}
+"""
+
+# ─── fake API response builders ──────────────────────────────────────────────
+
+def _csrf_response(token="validtoken123"):
+    """Fake CSRF token GET response."""
+    m = MagicMock()
+    m.status_code = 200
+    m.json.return_value = {"query": {"tokens": {"csrftoken": token}}}
+    return m
+
+
+def _upload_ok_response():
+    """Fake successful upload POST response."""
+    m = MagicMock()
+    m.status_code = 200
+    m.json.return_value = {
+        "upload": {
+            "result": "Success",
+            "imageinfo": {
+                "url": "https://upload.wikimedia.org/wikipedia/commons/a/a9/Example.jpg",
+                "descriptionurl": "https://commons.wikimedia.org/wiki/File:Example.jpg"
+            }
+        }
+    }
+    return m
+
+
+def _upload_fail_response(error_info="File is corrupt"):
+    """Fake failed upload POST response."""
+    m = MagicMock()
+    m.status_code = 200
+    m.json.return_value = {
+        "upload": {
+            "result": "Failure",
+            "error": {"info": error_info}
+        }
+    }
+    return m
+
+
+def _upload_no_imageinfo_response():
+    """Upload says Success but imageinfo is missing."""
+    m = MagicMock()
+    m.status_code = 200
+    m.json.return_value = {"upload": {"result": "Success"}}
+    return m
+
+
+# ─── SUCCESS TESTS ────────────────────────────────────────────────────────────
+
+class TestProcessUploadSuccess:
+    """Happy path — CSRF token fetched, file uploaded, result returned."""
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.os.path.exists", return_value=True)
+    @patch("builtins.open", mock_open(read_data=b"fake-image-bytes"))
+    @patch("utils.requests.post")
+    @patch("utils.requests.get")
+    def test_returns_dict_with_correct_keys(self, mock_get, mock_post, mock_exists):
+        mock_get.return_value = _csrf_response()
+        mock_post.return_value = _upload_ok_response()
+
+        result = process_upload(
+            "temp_images/file.jpg", "ExampleFile", "jpg",
+            "https://commons.wikimedia.org/w/api.php", MagicMock()
+        )
+
+        assert "wikipage_url" in result
+        assert "file_link" in result
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.os.path.exists", return_value=True)
+    @patch("builtins.open", mock_open(read_data=b"fake-image-bytes"))
+    @patch("utils.requests.post")
+    @patch("utils.requests.get")
+    def test_returns_correct_urls(self, mock_get, mock_post, mock_exists):
+        mock_get.return_value = _csrf_response()
+        mock_post.return_value = _upload_ok_response()
+
+        result = process_upload(
+            "temp_images/file.jpg", "ExampleFile", "jpg",
+            "https://commons.wikimedia.org/w/api.php", MagicMock()
+        )
+
+        assert result["wikipage_url"] == "https://commons.wikimedia.org/wiki/File:Example.jpg"
+        assert result["file_link"] == "https://upload.wikimedia.org/wikipedia/commons/a/a9/Example.jpg"
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.os.path.exists", return_value=True)
+    @patch("builtins.open", mock_open(read_data=b"fake-image-bytes"))
+    @patch("utils.requests.post")
+    @patch("utils.requests.get")
+    def test_csrf_token_is_sent_in_upload_post(self, mock_get, mock_post, mock_exists):
+        # The CSRF token from the GET must appear in the POST data
+        mock_get.return_value = _csrf_response("mytoken456")
+        mock_post.return_value = _upload_ok_response()
+
+        process_upload(
+            "temp_images/file.jpg", "ExampleFile", "jpg",
+            "https://commons.wikimedia.org/w/api.php", MagicMock()
+        )
+
+        post_data = mock_post.call_args[1]["data"]
+        assert post_data["token"] == "mytoken456"
+
+
+# ─── CSRF ERRORS ─────────────────────────────────────────────────────────────
+
+class TestProcessUploadCSRFErrors:
+    """Failures when fetching or validating the CSRF token."""
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.requests.get")
+    def test_anon_csrf_token_raises_auth_error(self, mock_get):
+        # "+\\" is the unauthenticated token — means OAuth session is invalid
+        mock_get.return_value = _csrf_response(token="+\\")
+
+        with pytest.raises(AuthenticationError) as exc:
+            process_upload(
+                "temp_images/file.jpg", "ExampleFile", "jpg",
+                "https://commons.wikimedia.org/w/api.php", MagicMock()
+            )
+
+        assert "Invalid CSRF token" in str(exc.value)
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.requests.get")
+    def test_csrf_timeout_raises_wiki_api_error(self, mock_get):
+        mock_get.side_effect = req.exceptions.Timeout()
+
+        with pytest.raises(WikiAPIError) as exc:
+            process_upload(
+                "temp_images/file.jpg", "ExampleFile", "jpg",
+                "https://commons.wikimedia.org/w/api.php", MagicMock()
+            )
+
+        assert "Timeout" in str(exc.value)
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.requests.get")
+    def test_csrf_connection_error_raises_wiki_api_error(self, mock_get):
+        mock_get.side_effect = req.exceptions.ConnectionError("refused")
+
+        with pytest.raises(WikiAPIError):
+            process_upload(
+                "temp_images/file.jpg", "ExampleFile", "jpg",
+                "https://commons.wikimedia.org/w/api.php", MagicMock()
+            )
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.requests.get")
+    def test_csrf_missing_key_raises_wiki_api_error(self, mock_get):
+        # Response is valid JSON but missing the expected "tokens" key
+        m = MagicMock()
+        m.status_code = 200
+        m.json.return_value = {"query": {}}  # no "tokens" key
+        mock_get.return_value = m
+
+        with pytest.raises(WikiAPIError) as exc:
+            process_upload(
+                "temp_images/file.jpg", "ExampleFile", "jpg",
+                "https://commons.wikimedia.org/w/api.php", MagicMock()
+            )
+
+        assert "CSRF" in str(exc.value)
+
+
+# ─── FILE ERRORS ──────────────────────────────────────────────────────────────
+
+class TestProcessUploadFileErrors:
+    """Failures when the local file cannot be found or read."""
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.os.path.exists", return_value=False)
+    @patch("utils.requests.get")
+    def test_file_not_found_raises_file_op_error(self, mock_get, mock_exists):
+        mock_get.return_value = _csrf_response()
+
+        with pytest.raises(FileOperationError) as exc:
+            process_upload(
+                "temp_images/missing.jpg", "ExampleFile", "jpg",
+                "https://commons.wikimedia.org/w/api.php", MagicMock()
+            )
+
+        assert "not found" in str(exc.value)
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.os.path.exists", return_value=True)
+    @patch("builtins.open")
+    @patch("utils.requests.get")
+    def test_oserror_reading_file_raises_file_op_error(self, mock_get, mock_open_fn, mock_exists):
+        mock_get.return_value = _csrf_response()
+        mock_open_fn.side_effect = OSError("Permission denied")
+
+        with pytest.raises(FileOperationError) as exc:
+            process_upload(
+                "temp_images/file.jpg", "ExampleFile", "jpg",
+                "https://commons.wikimedia.org/w/api.php", MagicMock()
+            )
+
+        assert "Could not read file" in str(exc.value)
+
+
+# ─── UPLOAD RESULT ERRORS ─────────────────────────────────────────────────────
+
+class TestProcessUploadResultErrors:
+    """Failures after the POST is sent — bad result from the Wiki API."""
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.os.path.exists", return_value=True)
+    @patch("builtins.open", mock_open(read_data=b"fake-image-bytes"))
+    @patch("utils.requests.post")
+    @patch("utils.requests.get")
+    def test_upload_result_failure_raises_wiki_api_error(self, mock_get, mock_post, mock_exists):
+        mock_get.return_value = _csrf_response()
+        mock_post.return_value = _upload_fail_response("File is corrupt")
+
+        with pytest.raises(WikiAPIError) as exc:
+            process_upload(
+                "temp_images/file.jpg", "ExampleFile", "jpg",
+                "https://commons.wikimedia.org/w/api.php", MagicMock()
+            )
+
+        assert "Upload failed" in str(exc.value)
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.os.path.exists", return_value=True)
+    @patch("builtins.open", mock_open(read_data=b"fake-image-bytes"))
+    @patch("utils.requests.post")
+    @patch("utils.requests.get")
+    def test_upload_missing_imageinfo_raises_wiki_api_error(self, mock_get, mock_post, mock_exists):
+        # Upload says Success but no imageinfo in the response
+        mock_get.return_value = _csrf_response()
+        mock_post.return_value = _upload_no_imageinfo_response()
+
+        with pytest.raises(WikiAPIError) as exc:
+            process_upload(
+                "temp_images/file.jpg", "ExampleFile", "jpg",
+                "https://commons.wikimedia.org/w/api.php", MagicMock()
+            )
+
+        assert "imageinfo" in str(exc.value)
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.os.path.exists", return_value=True)
+    @patch("builtins.open", mock_open(read_data=b"fake-image-bytes"))
+    @patch("utils.requests.post")
+    @patch("utils.requests.get")
+    def test_upload_timeout_raises_wiki_api_error(self, mock_get, mock_post, mock_exists):
+        mock_get.return_value = _csrf_response()
+        mock_post.side_effect = req.exceptions.Timeout()
+
+        with pytest.raises(WikiAPIError) as exc:
+            process_upload(
+                "temp_images/file.jpg", "ExampleFile", "jpg",
+                "https://commons.wikimedia.org/w/api.php", MagicMock()
+            )
+
+        assert "Timeout" in str(exc.value)
+
+    @patch("utils.log_timed_api_call", _mock_timed_api_call)
+    @patch("utils.os.path.exists", return_value=True)
+    @patch("builtins.open", mock_open(read_data=b"fake-image-bytes"))
+    @patch("utils.requests.post")
+    @patch("utils.requests.get")
+    def test_upload_request_error_raises_wiki_api_error(self, mock_get, mock_post, mock_exists):
+        mock_get.return_value = _csrf_response()
+        mock_post.side_effect = req.exceptions.RequestException("network error")
+
+        with pytest.raises(WikiAPIError):
+            process_upload(
+                "temp_images/file.jpg", "ExampleFile", "jpg",
+                "https://commons.wikimedia.org/w/api.php", MagicMock()
+            )
+
+
+# =============================================================================
+# get_localized_wikitext() TESTS
+# =============================================================================
+
+# ─── wikitext fixtures ───────────────────────────────────────────────────────
+
+# A template that IS in TEMPLATES with an Article param
+WIKITEXT_WITH_TEMPLATE = "{{Non-free album cover|Article=Cat|Description=Test}}"
+
+# A template NOT in TEMPLATES — should be ignored
+WIKITEXT_UNKNOWN_TEMPLATE = "{{SomeRandomTemplate|Article=Cat}}"
+
+# Two templates in TEMPLATES — lets us test that one failure doesn't abort the rest
+WIKITEXT_TWO_TEMPLATES = (
+    "{{Non-free album cover|Article=Cat}}\n"
+    "{{Non-free film screenshot|Article=Dog}}"
+)
+
+
+def _langlinks_response(lang, title):
+    """Fake langlinks API response with one translation."""
+    m = MagicMock()
+    m.status_code = 200
+    m.json.return_value = {
+        "query": {
+            "pages": [
+                {
+                    "title": "Cat",
+                    "langlinks": [{"lang": lang, "title": title}]
+                }
+            ]
+        }
+    }
+    return m
+
+
+def _no_langlinks_response():
+    """Fake langlinks API response with no translations."""
+    m = MagicMock()
+    m.status_code = 200
+    m.json.return_value = {"query": {"pages": [{"title": "Cat"}]}}
+    return m
+
+
+# ─── TESTS ────────────────────────────────────────────────────────────────────
+
+class TestGetLocalizedWikitext:
+
+    @patch("utils.requests.get")
+    def test_always_returns_a_string(self, mock_get):
+        mock_get.return_value = _langlinks_response("fr", "Chat")
+        result = get_localized_wikitext(WIKITEXT_WITH_TEMPLATE, "https://en.wikipedia.org/w/api.php", "fr")
+        assert isinstance(result, str)
+
+    @patch("utils.requests.get")
+    def test_localizes_article_param_when_langlink_found(self, mock_get):
+        # The French translation of "Cat" is "Chat" — Article param should be updated
+        mock_get.return_value = _langlinks_response("fr", "Chat")
+        result = get_localized_wikitext(WIKITEXT_WITH_TEMPLATE, "https://en.wikipedia.org/w/api.php", "fr")
+        assert "Chat" in result
+
+    @patch("utils.requests.get")
+    def test_leaves_article_unchanged_when_no_langlink_for_target(self, mock_get):
+        # API returns langlinks but none match the requested language
+        mock_get.return_value = _no_langlinks_response()
+        result = get_localized_wikitext(WIKITEXT_WITH_TEMPLATE, "https://en.wikipedia.org/w/api.php", "fr")
+        # Original value "Cat" should still be present
+        assert "Cat" in result
+
+    @patch("utils.requests.get")
+    def test_ignores_templates_not_in_templates_list(self, mock_get):
+        # Template not in TEMPLATES → no API call made, wikitext unchanged
+        result = get_localized_wikitext(WIKITEXT_UNKNOWN_TEMPLATE, "https://en.wikipedia.org/w/api.php", "fr")
+        mock_get.assert_not_called()
+        assert "Cat" in result
+
+    @patch("utils.requests.get")
+    def test_continues_processing_after_single_article_timeout(self, mock_get):
+        # First article times out, second should still be processed
+        mock_get.side_effect = [
+            req.exceptions.Timeout(),
+            _langlinks_response("fr", "Chien"),
+        ]
+        # Should not raise — timeouts are caught per-article
+        result = get_localized_wikitext(
+            WIKITEXT_TWO_TEMPLATES, "https://en.wikipedia.org/w/api.php", "fr"
+        )
+        assert isinstance(result, str)
+
+    @patch("utils.requests.get")
+    def test_continues_processing_after_single_article_request_error(self, mock_get):
+        mock_get.side_effect = [
+            req.exceptions.RequestException("network error"),
+            _langlinks_response("fr", "Chien"),
+        ]
+        result = get_localized_wikitext(
+            WIKITEXT_TWO_TEMPLATES, "https://en.wikipedia.org/w/api.php", "fr"
+        )
+        assert isinstance(result, str)
+
+    @patch("utils.mwparserfromhell.parse")
+    def test_returns_original_wikitext_on_outer_exception(self, mock_parse):
+        # If mwparserfromhell.parse itself crashes, return the original unchanged
+        mock_parse.side_effect = Exception("parse error")
+        original = "{{Non-free album cover|Article=Cat}}"
+        result = get_localized_wikitext(original, "https://en.wikipedia.org/w/api.php", "fr")
+        assert result == original

--- a/utils.py
+++ b/utils.py
@@ -10,6 +10,20 @@ logger = get_logger(__name__)
 import os
 import datetime
 import requests
+
+
+def cleanup_temp_file(file_path):
+    """Remove a temp file from disk. Silently ignores missing files."""
+    if not file_path:
+        return
+    try:
+        if os.path.exists(file_path):
+            os.remove(file_path)
+            logger.info(f"Cleaned up temp file: {file_path}")
+    except OSError as e:
+        logger.warning(f"Failed to remove temp file {file_path}: {e}")
+
+
 def download_image(src_project, src_lang, src_filename):
     """
     Download an image from a Wiki source.
@@ -162,17 +176,19 @@ def download_image(src_project, src_lang, src_filename):
         ) from e
 
     except OSError as e:
+        partial = file_path if "file_path" in locals() else None
+        cleanup_temp_file(partial)
         log_file_operation(
             logger,
             operation="write",
-            file_path=file_path if "file_path" in locals() else "unknown",
+            file_path=partial or "unknown",
             success=False,
             error=str(e)
         )
         raise FileOperationError(
             f"Failed to write image file: {str(e)}",
             operation="write",
-            file_path=file_path if "file_path" in locals() else "unknown"
+            file_path=partial or "unknown"
         ) from e
 
 

--- a/utils.py
+++ b/utils.py
@@ -2,11 +2,26 @@ import datetime
 import requests
 import mwparserfromhell
 from templatelist import TEMPLATES
+from logging_config import get_logger, log_file_operation, log_timed_api_call, log_exception
+from exceptions import WikiAPIError, FileOperationError, ResourceNotFoundError, AuthenticationError
+logger = get_logger(__name__)
 
+
+import os
+import datetime
+import requests
 def download_image(src_project, src_lang, src_filename):
-    src_endpoint = "https://"+ src_lang + "." + src_project + ".org/w/api.php"
+    """
+    Download an image from a Wiki source.
 
-    param = {
+    Raises:
+        WikiAPIError
+        FileOperationError
+        ResourceNotFoundError
+    """
+    src_endpoint = f"https://{src_lang}.{src_project}.org/w/api.php"
+
+    params = {
         "action": "query",
         "format": "json",
         "prop": "imageinfo",
@@ -15,98 +30,371 @@ def download_image(src_project, src_lang, src_filename):
         "iilocalonly": 1
     }
 
-    page = requests.get(url=src_endpoint, params=param).json()['query']['pages']
-
+    # ─────────────────────────────────────
+    # Fetch metadata
+    # ─────────────────────────────────────
     try:
-        image_url = list (page.values()) [0]["imageinfo"][0]["url"]
-    except KeyError:
-        return None
+        logger.info(
+            f"Fetching image info for {src_filename} "
+            f"from {src_lang}.{src_project}.org"
+        )
 
-    # Create a unique file name based on time
-    current_time = str(datetime.datetime.now())
-    get_filename = current_time.replace(':', '_')
-    get_filename = get_filename.replace(' ', '_')
+        with log_timed_api_call(logger, src_endpoint, "GET") as context:
+            response = requests.get(
+                url=src_endpoint,
+                params=params,
+                timeout=30,
+                headers=getHeader()
+            )
+            response.raise_for_status()
+            context["status_code"] = response.status_code
+            #       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+            # this is why yield returns context dict
+            # you set the status_code here
+            # log_timed_api_call reads it in the else block
 
-    # Download the Image File
-    r = requests.get(image_url, allow_redirects=True)
-    filename = get_filename + "." + r.headers.get('content-type').replace('image/', '')
-    open("temp_images/" + filename, 'wb').write(r.content)
+        data = response.json()
+        logger.info(f"Raw API response for {src_filename}: {data}")
+        page = data.get("query", {}).get("pages", {})
 
-    return filename
+        if not page:
+            raise ResourceNotFoundError(
+                f"No page data returned for {src_filename}",
+                resource_type="image",
+                resource_id=src_filename
+            )
+
+        page_data = list(page.values())[0]
+
+        if "imageinfo" not in page_data:
+            raise ResourceNotFoundError(
+                f"Image not found: {src_filename}",
+                resource_type="image",
+                resource_id=src_filename,
+                details={"page_data": page_data}
+            )
+
+        image_url = page_data["imageinfo"][0]["url"]
+        logger.info(f"Found image URL: {image_url}")
+
+    except requests.exceptions.Timeout as e:
+        raise WikiAPIError(
+            f"Timeout while fetching image info for {src_filename}",
+            api_endpoint=src_endpoint,
+            details={"timeout_seconds": 30}
+        ) from e
+
+    except requests.exceptions.RequestException as e:
+        raise WikiAPIError(
+            f"Failed to fetch image info: {str(e)}",
+            api_endpoint=src_endpoint,
+            status_code=getattr(e.response, "status_code", None)
+        ) from e
+
+    except (KeyError, IndexError) as e:
+        raise ResourceNotFoundError(
+            f"Invalid response format for {src_filename}",
+            resource_type="image",
+            resource_id=src_filename,
+            details={"error": str(e)}
+        ) from e
+
+    # ─────────────────────────────────────
+    # Download file
+    # ─────────────────────────────────────
+    try:
+        filename_base = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        logger.info(f"Downloading image from {image_url}")
+
+        with log_timed_api_call(logger, image_url, "GET") as context:
+            r = requests.get(image_url, allow_redirects=True, timeout=60, headers=getHeader())
+            r.raise_for_status()
+            context["status_code"] = r.status_code
+
+        content_type = r.headers.get("Content-Type", "image/jpeg")
+        mime = content_type.split(";")[0]
+        file_extension = mime.replace("image/", "")
+        filename = f"{filename_base}.{file_extension}"
+
+        os.makedirs("temp_images", exist_ok=True)
+        file_path = os.path.join("temp_images", filename)
+
+        with open(file_path, "wb") as f:
+            f.write(r.content)
+
+        log_file_operation(
+            logger,
+            operation="download",
+            file_path=file_path,
+            success=True
+        )
+
+        logger.info(f"Image downloaded successfully: {filename}")
+        return filename
+
+    except requests.exceptions.Timeout as e:
+        log_file_operation(
+            logger,
+            operation="download",
+            file_path=image_url,
+            success=False,
+            error=str(e)
+        )
+        raise FileOperationError(
+            f"Timeout while downloading image from {image_url}",
+            operation="download",
+            file_path=image_url,
+            details={"timeout_seconds": 60}
+        ) from e
+
+    except requests.exceptions.RequestException as e:
+        log_file_operation(
+            logger,
+            operation="download",
+            file_path=image_url,
+            success=False,
+            error=str(e)
+        )
+        raise FileOperationError(
+            f"Failed to download image: {str(e)}",
+            operation="download",
+            file_path=image_url
+        ) from e
+
+    except OSError as e:
+        log_file_operation(
+            logger,
+            operation="write",
+            file_path=file_path if "file_path" in locals() else "unknown",
+            success=False,
+            error=str(e)
+        )
+        raise FileOperationError(
+            f"Failed to write image file: {str(e)}",
+            operation="write",
+            file_path=file_path if "file_path" in locals() else "unknown"
+        ) from e
 
 
+# Uploads a file to the target wiki using OAuth — fetches CSRF token first, then POSTs the file
 def process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses):
-    # API Parameter to get CSRF Token
+    logger.info(f"Starting upload process for {tr_filename}.{src_fileext}")
+
     csrf_param = {
         "action": "query",
         "meta": "tokens",
         "format": "json"
     }
 
-    response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses)
-    csrf_token = response.json()["query"]["tokens"]["csrftoken"]
-
-    # API Parameter to upload the file
-    upload_param = {
-        "action": "upload",
-        "filename": tr_filename + "." + src_fileext,
-        "format": "json",
-        "token": csrf_token,
-        "ignorewarnings": 1
-    }
-
-    # Read the file for POST request
-    file = {
-        'file': open(file_path, 'rb')
-    }
-
-    response = requests.post(url=tr_endpoint, files=file, data=upload_param, auth=ses).json()
-
-    # Try block to get Link and URL
+    # ─────────────────────────────────────
+    # Fetch CSRF token
+    # ─────────────────────────────────────
     try:
-        wikifile_url = response["upload"]["imageinfo"]["descriptionurl"]
-        file_link = response["upload"]["imageinfo"]["url"]
-    except KeyError:
-        return None
+        logger.info("Fetching CSRF token")
 
-    return {
-        "wikipage_url": wikifile_url,
-        "file_link": file_link
-    }
+        with log_timed_api_call(logger, tr_endpoint, "GET") as context:
+            response = requests.get(
+                url=tr_endpoint,
+                params=csrf_param,
+                auth=ses,
+                timeout=30,
+                headers=getHeader()
+            )
+            response.raise_for_status()
+            context["status_code"] = response.status_code
+
+        csrf_token = response.json()["query"]["tokens"]["csrftoken"]
+
+        if csrf_token == "+\\":
+            raise AuthenticationError("Invalid CSRF token — OAuth session may have expired")
+
+    except requests.exceptions.Timeout as e:
+        raise WikiAPIError(
+            "Timeout while fetching CSRF token",
+            api_endpoint=tr_endpoint,
+            details={"timeout_seconds": 30}
+        ) from e
+
+    except requests.exceptions.RequestException as e:
+        raise WikiAPIError(
+            f"Failed to fetch CSRF token: {str(e)}",
+            api_endpoint=tr_endpoint,
+            status_code=getattr(e.response, "status_code", None)
+        ) from e
+
+    except KeyError as e:
+        raise WikiAPIError(
+            f"Unexpected CSRF response format: missing {str(e)}",
+            api_endpoint=tr_endpoint
+        ) from e
+
+    # ─────────────────────────────────────
+    # Upload file
+    # ─────────────────────────────────────
+    try:
+        if not os.path.exists(file_path):
+            raise FileOperationError(
+                f"File not found before upload: {file_path}",
+                operation="check_file",
+                file_path=file_path
+            )
+
+        upload_param = {
+            "action": "upload",
+            "filename": f"{tr_filename}.{src_fileext}",
+            "format": "json",
+            "token": csrf_token,
+            "ignorewarnings": 1
+        }
+
+        logger.info(f"Uploading {file_path} to {tr_endpoint}")
+
+        with log_timed_api_call(logger, tr_endpoint, "POST") as context:
+            with open(file_path, "rb") as f:
+                response = requests.post(
+                    url=tr_endpoint,
+                    files={"file": f},
+                    data=upload_param,
+                    auth=ses,
+                    timeout=120
+                )
+            response.raise_for_status()
+            context["status_code"] = response.status_code
+
+        result = response.json()
+        upload_result = result.get("upload", {})
+
+        if upload_result.get("result") != "Success":
+            error_info = upload_result.get("error", {}).get("info", "Unknown error")
+            raise WikiAPIError(
+                f"Upload failed: {error_info}",
+                api_endpoint=tr_endpoint,
+                details={"upload_result": upload_result}
+            )
+
+        if "imageinfo" not in upload_result:
+            raise WikiAPIError(
+                "Upload succeeded but no imageinfo returned",
+                api_endpoint=tr_endpoint,
+                details={"upload_result": upload_result}
+            )
+
+        wikifile_url = upload_result["imageinfo"]["descriptionurl"]
+        file_link = upload_result["imageinfo"]["url"]
+
+        log_file_operation(logger, "upload", file_path, success=True)
+        logger.info(f"Upload successful: {tr_filename}.{src_fileext}")
+
+        return {
+            "wikipage_url": wikifile_url,
+            "file_link": file_link
+        }
+
+    except requests.exceptions.Timeout as e:
+        raise WikiAPIError(
+            "Timeout while uploading file",
+            api_endpoint=tr_endpoint,
+            details={"timeout_seconds": 120}
+        ) from e
+
+    except requests.exceptions.RequestException as e:
+        log_file_operation(logger, "upload", file_path, success=False, error=str(e))
+        raise WikiAPIError(
+            f"Failed to upload file: {str(e)}",
+            api_endpoint=tr_endpoint,
+            status_code=getattr(e.response, "status_code", None)
+        ) from e
+
+    except OSError as e:
+        log_exception(logger, e, extra_context={"file_path": file_path})
+        raise FileOperationError(
+            f"Could not read file for upload: {str(e)}",
+            operation="read",
+            file_path=file_path
+        ) from e
 
 
+# Replaces the Article parameter in wiki templates with its translated title in the target language
 def get_localized_wikitext(wikitext, src_endpoint, target_lang):
-    wikicode = mwparserfromhell.parse(wikitext)
+    logger.info(f"Localizing wikitext for target language: {target_lang}")
 
-    for template in wikicode.filter_templates():
-        if template.name.strip() in TEMPLATES:
-            if template.has("Article"):
-                article_value = template.get("Article")
+    try:
+        wikicode = mwparserfromhell.parse(wikitext)
+        templates_processed = 0
+        templates_localized = 0
 
-                if article_value:
-                    article_title = article_value.value.strip()
-                    lang_param = {
-                        "action": "query",
-                        "format": "json",
-                        "prop": "langlinks",
-                        "titles": article_title,
-                        "formatversion": "2"
-                    }
+        for template in wikicode.filter_templates():
+            if template.name.strip() in TEMPLATES:
+                templates_processed += 1
 
-                    try:
-                        response = requests.get(url=src_endpoint, params=lang_param)
-                        response.raise_for_status()
-                        langlinks = response.json()["query"]["pages"][0]["langlinks"]
+                if template.has("Article"):
+                    article_value = template.get("Article")
 
-                        for langlink in langlinks:
-                            if langlink["lang"] == target_lang:
-                                template.add("Article", langlink["title"])
-                                break
-                    except:
-                        return str(wikicode)
+                    if article_value:
+                        article_title = article_value.value.strip()
+                        lang_param = {
+                            "action": "query",
+                            "format": "json",
+                            "prop": "langlinks",
+                            "titles": article_title,
+                            "formatversion": "2"
+                        }
 
-    return str(wikicode)
+                        # Per-article lookup — failures skip that article, not the whole function
+                        try:
+                            response = requests.get(
+                                url=src_endpoint,
+                                params=lang_param,
+                                timeout=30,
+                                headers=getHeader()
+                            )
+                            response.raise_for_status()
 
+                            pages = response.json().get("query", {}).get("pages", [])
+
+                            if pages and "langlinks" in pages[0]:
+                                for langlink in pages[0]["langlinks"]:
+                                    if langlink["lang"] == target_lang:
+                                        template.add("Article", langlink["title"])
+                                        templates_localized += 1
+                                        logger.info(
+                                            f"Localized: {article_title} -> {langlink['title']}"
+                                        )
+                                        break
+
+                        except requests.exceptions.Timeout:
+                            logger.warning(
+                                f"Timeout fetching langlinks for {article_title}, skipping"
+                            )
+                            continue
+
+                        except requests.exceptions.RequestException as e:
+                            logger.warning(
+                                f"Request error for {article_title}: {str(e)}, skipping"
+                            )
+                            continue
+
+                        except (KeyError, IndexError) as e:
+                            logger.warning(
+                                f"Unexpected response format for {article_title}, skipping"
+                            )
+                            continue
+
+        logger.info(
+            f"Localization complete: {templates_localized}/{templates_processed} templates localized"
+        )
+        return str(wikicode)
+
+    except Exception as e:
+        logger.warning(f"Failed to localize wikitext: {str(e)}, returning original")
+        log_exception(logger, e, extra_context={
+            "function": "get_localized_wikitext",
+            "target_lang": target_lang
+        })
+        return wikitext
+
+
+# Returns the User-Agent header identifying this tool to the Wikimedia API
 def getHeader():
     agent = 'Wikifile-transfer/1.0 (https://wikifile-transfer.toolforge.org; 0freerunning@gmail.com)'
     return {


### PR DESCRIPTION
Added temp file cleanup to prevent orphaned files accumulating in temp_images/. Files now get deleted after every upload — success or failure. Async uploads use a _should_cleanup flag so the file survives retries but is removed once the task reaches a terminal outcome.

Note: This PR depends on the error handling PR (T415715) and should be merged after it.