### PR TITLE
Fix temp file cleanup after upload in upload_image_task

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -11,48 +11,55 @@ def upload_image_task(self, file_path, tr_filename, src_fileext, tr_endpoint, OA
         resource_owner_key=OAuthObj["key"],
         resource_owner_secret=OAuthObj["secret"]
     )
-    self.update_state(state='PROGRESS', meta={'current': 0, 'total': 100})
-    
-    # API Parameter to get CSRF Token
-    csrf_param = {
-        "action": "query",
-        "meta": "tokens",
-        "format": "json"
-    }
 
-    response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses)
-    csrf_token = response.json()["query"]["tokens"]["csrftoken"]
-
-    self.update_state(state='PROGRESS', meta={'current': 25, 'total': 100})
-
-    # API Parameter to upload the file
-    upload_param = {
-        "action": "upload",
-        "filename": tr_filename + "." + src_fileext,
-        "format": "json",
-        "token": csrf_token,
-        "ignorewarnings": 1
-    }
-
-    # Read the file for POST request
-    file = {
-        'file': open(file_path, 'rb')
-    }
-
-    response = requests.post(url=tr_endpoint, files=file, data=upload_param, auth=ses).json()
-
-    self.update_state(state='PROGRESS', meta={'current': 75, 'total': 100})
-
-    # Try block to get Link and URL
     try:
-        wikifile_url = response["upload"]["imageinfo"]["descriptionurl"]
-        file_link = response["upload"]["imageinfo"]["url"]
-    except KeyError:
-        return {"success": False, "data": {}, "errors": ["Upload failed"]}
+        self.update_state(state='PROGRESS', meta={'current': 0, 'total': 100})
 
-    self.update_state(state='PROGRESS', meta={'current': 100, 'total': 100})
+        # API Parameter to get CSRF Token
+        csrf_param = {
+            "action": "query",
+            "meta": "tokens",
+            "format": "json"
+        }
 
-    return {
-        "wikipage_url": wikifile_url,
-        "file_link": file_link
-    }
+        response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses)
+        csrf_token = response.json()["query"]["tokens"]["csrftoken"]
+
+        self.update_state(state='PROGRESS', meta={'current': 25, 'total': 100})
+
+        # API Parameter to upload the file
+        upload_param = {
+            "action": "upload",
+            "filename": tr_filename + "." + src_fileext,
+            "format": "json",
+            "token": csrf_token,
+            "ignorewarnings": 1
+        }
+
+        # Read the file for POST request
+        with open(file_path, 'rb') as f:
+            file = {
+                'file': f
+            }
+
+            response = requests.post(url=tr_endpoint, files=file, data=upload_param, auth=ses).json()
+
+        self.update_state(state='PROGRESS', meta={'current': 75, 'total': 100})
+
+        # Try block to get Link and URL
+        try:
+            wikifile_url = response["upload"]["imageinfo"]["descriptionurl"]
+            file_link = response["upload"]["imageinfo"]["url"]
+        except KeyError:
+            return {"success": False, "data": {}, "errors": ["Upload failed"]}
+
+        self.update_state(state='PROGRESS', meta={'current': 100, 'total': 100})
+
+        return {
+            "wikipage_url": wikifile_url,
+            "file_link": file_link
+        }
+    finally:
+        # delete temporary file
+        if os.path.exists(file_path):
+            os.remove(file_path)


### PR DESCRIPTION
Temporary files stored in temp_images were not deleted after upload,
which could lead to storage accumulation.

This patch adds cleanup logic using a finally block so the temporary
file is removed regardless of upload success or failure.