### PR TITLE
fix: resolve AxiosError 500 on file uploads

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@
 from flask import Flask, request, session, jsonify, render_template
 from flask_mwoauth import MWOAuth
 from flask_migrate import Migrate
-from utils import download_image, get_localized_wikitext, getHeader, process_upload
+from utils import download_image, get_localized_wikitext, getHeader, process_upload, cleanup_temp_file
 from flask_cors import CORS
 import requests_oauthlib
 import requests
@@ -63,38 +63,61 @@ def index():
 @app.route('/api/upload', methods=['POST'])
 def upload():
     if request.method == 'POST':
-        data = request.get_json()
-        src_url = urllib.parse.unquote(data.get('srcUrl'))
-        match = re.findall(r"(\w+)\.(\w+)\.org/wiki/", src_url)
+        downloaded_filename = None
+        file_path = None
+        try:
+            data = request.get_json(silent=True)
+            if not data:
+                return jsonify({"success": False, "data": {}, "errors": ["Invalid JSON payload"]}), 400
 
-        src_project = match[0][1]
-        src_lang = match[0][0]
-        src_filename = src_url.split('/')[-1]
-        src_fileext = src_filename.split('.')[-1]
+            src_url = data.get('srcUrl')
+            if not src_url:
+                return jsonify({"success": False, "data": {}, "errors": ["Missing srcUrl"]}), 400
 
-        # Downloading the source file and getting saved file name
-        downloaded_filename = download_image(src_project, src_lang, src_filename)
+            src_url = urllib.parse.unquote(src_url)
+            match = re.findall(r"(\w+)\.(\w+)\.org/wiki/", src_url)
 
-        # Getting Target Details
-        tr_project = data.get('trproject')
-        tr_lang = data.get('trlang')
-        tr_filename = data.get('trfilename')
-        tr_filename = urllib.parse.unquote(tr_filename)
-        tr_endpoint = "https://" + tr_lang + "." + tr_project + ".org/w/api.php"
+            if not match or len(match[0]) < 2:
+                return jsonify({"success": False, "data": {}, "errors": ["Invalid source URL format"]}), 400
 
-        # Authenticate Session
-        ses = authenticated_session()
+            src_project = match[0][1]
+            src_lang = match[0][0]
+            src_filename = src_url.split('/')[-1]
+            src_fileext = src_filename.split('.')[-1]
 
-        # Check whether we have enough data or not
-        if None not in (downloaded_filename, tr_filename, src_fileext, ses):
+            # Downloading the source file and getting saved file name
+            downloaded_filename = download_image(src_project, src_lang, src_filename)
+
+            if downloaded_filename is None:
+                return jsonify({"success": False, "data": {}, "errors": ["Failed to download source file"]}), 400
+
+            # Getting Target Details
+            tr_project = data.get('trproject')
+            tr_lang = data.get('trlang')
+            tr_filename = data.get('trfilename')
+
+            if not all([tr_project, tr_lang, tr_filename]):
+                cleanup_temp_file('temp_images/' + downloaded_filename)
+                return jsonify({"success": False, "data": {}, "errors": ["Missing target project, language, or filename"]}), 400
+
+            tr_filename = urllib.parse.unquote(tr_filename)
+            tr_endpoint = "https://" + tr_lang + "." + tr_project + ".org/w/api.php"
+
+            # Authenticate Session
+            ses = authenticated_session()
+
+            if ses is None:
+                cleanup_temp_file('temp_images/' + downloaded_filename)
+                return jsonify({"success": False, "data": {}, "errors": ["User not authenticated. Please log in."]}), 401
+
             file_path = 'temp_images/' + downloaded_filename
             file_size = os.path.getsize(file_path)
 
             if file_size < 50 * 1024 * 1024:  # 50 MB
-                # Process synchronously
+                # Process synchronously (process_upload handles temp file cleanup)
                 resp = process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses)
                 if resp is None:
-                    return jsonify({"success": False, "data": {}, "errors": ["Upload failed"]}), 500
+                    return jsonify({"success": False, "data": {}, "errors": ["Upload to target wiki failed. Check backend logs for details."]}), 500
 
                 resp["source"] = src_url
 
@@ -113,8 +136,17 @@ def upload():
                 }
                 task = upload_image_task.delay(file_path, tr_filename, src_fileext, tr_endpoint, OAuthObj)
                 return jsonify({"success": True, "task_id": task.id}), 202
-        else:
-            return jsonify({"success": False, "data": {}, "errors": ["Not enough data"]}), 400
+
+        except KeyError as e:
+            logger.error("Missing key in upload request: %s", e)
+            if downloaded_filename:
+                cleanup_temp_file('temp_images/' + downloaded_filename)
+            return jsonify({"success": False, "data": {}, "errors": [f"Missing required field: {e}"]}), 400
+        except Exception as e:
+            logger.error("Unexpected error in /api/upload: %s", e, exc_info=True)
+            if downloaded_filename:
+                cleanup_temp_file('temp_images/' + downloaded_filename)
+            return jsonify({"success": False, "data": {}, "errors": ["Internal server error. Please try again."]}), 500
     else:
         return jsonify({"success": False, "data": {}, "errors": ["Invalid Request"]}), 400
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ redis
 gunicorn
 cryptography
 mwparserfromhell
+pytest

--- a/tasks.py
+++ b/tasks.py
@@ -2,57 +2,105 @@ from celeryWorker import app
 import requests
 import requests_oauthlib
 import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def cleanup_temp_file(file_path):
+    """Safely remove a temporary file."""
+    try:
+        if file_path and os.path.exists(file_path):
+            os.remove(file_path)
+            logger.info("Cleaned up temp file: %s", file_path)
+    except OSError as e:
+        logger.warning("Failed to clean up temp file %s: %s", file_path, e)
+
 
 @app.task(bind=True)
 def upload_image_task(self, file_path, tr_filename, src_fileext, tr_endpoint, OAuthObj):
-    ses = requests_oauthlib.OAuth1(
-        client_key=OAuthObj["consumer_key"],
-        client_secret= OAuthObj["consumer_secret"],
-        resource_owner_key=OAuthObj["key"],
-        resource_owner_secret=OAuthObj["secret"]
-    )
-    self.update_state(state='PROGRESS', meta={'current': 0, 'total': 100})
-    
-    # API Parameter to get CSRF Token
-    csrf_param = {
-        "action": "query",
-        "meta": "tokens",
-        "format": "json"
-    }
-
-    response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses)
-    csrf_token = response.json()["query"]["tokens"]["csrftoken"]
-
-    self.update_state(state='PROGRESS', meta={'current': 25, 'total': 100})
-
-    # API Parameter to upload the file
-    upload_param = {
-        "action": "upload",
-        "filename": tr_filename + "." + src_fileext,
-        "format": "json",
-        "token": csrf_token,
-        "ignorewarnings": 1
-    }
-
-    # Read the file for POST request
-    file = {
-        'file': open(file_path, 'rb')
-    }
-
-    response = requests.post(url=tr_endpoint, files=file, data=upload_param, auth=ses).json()
-
-    self.update_state(state='PROGRESS', meta={'current': 75, 'total': 100})
-
-    # Try block to get Link and URL
+    file_handle = None
     try:
-        wikifile_url = response["upload"]["imageinfo"]["descriptionurl"]
-        file_link = response["upload"]["imageinfo"]["url"]
-    except KeyError:
-        return {"success": False, "data": {}, "errors": ["Upload failed"]}
+        ses = requests_oauthlib.OAuth1(
+            client_key=OAuthObj["consumer_key"],
+            client_secret=OAuthObj["consumer_secret"],
+            resource_owner_key=OAuthObj["key"],
+            resource_owner_secret=OAuthObj["secret"]
+        )
+        self.update_state(state='PROGRESS', meta={'current': 0, 'total': 100})
 
-    self.update_state(state='PROGRESS', meta={'current': 100, 'total': 100})
+        # API Parameter to get CSRF Token
+        csrf_param = {
+            "action": "query",
+            "meta": "tokens",
+            "format": "json"
+        }
 
-    return {
-        "wikipage_url": wikifile_url,
-        "file_link": file_link
-    }
+        response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses)
+        response.raise_for_status()
+        token_data = response.json()
+
+        # Validate CSRF token response
+        try:
+            csrf_token = token_data["query"]["tokens"]["csrftoken"]
+        except KeyError:
+            logger.error("Failed to retrieve CSRF token. Response: %s", token_data)
+            return {"success": False, "data": {}, "errors": ["Failed to retrieve CSRF token"]}
+
+        self.update_state(state='PROGRESS', meta={'current': 25, 'total': 100})
+
+        # API Parameter to upload the file
+        upload_param = {
+            "action": "upload",
+            "filename": tr_filename + "." + src_fileext,
+            "format": "json",
+            "token": csrf_token,
+            "ignorewarnings": 1
+        }
+
+        # Read the file for POST request
+        file_handle = open(file_path, 'rb')
+        file = {'file': file_handle}
+
+        response = requests.post(url=tr_endpoint, files=file, data=upload_param, auth=ses)
+        response.raise_for_status()
+        result = response.json()
+
+        self.update_state(state='PROGRESS', meta={'current': 75, 'total': 100})
+
+        # Check for MediaWiki API-level error
+        if "error" in result:
+            error_code = result["error"].get("code", "unknown")
+            error_info = result["error"].get("info", "No details provided")
+            logger.error("MediaWiki upload error: [%s] %s", error_code, error_info)
+            return {"success": False, "data": {}, "errors": [f"MediaWiki error: {error_info}"]}
+
+        # Try block to get Link and URL
+        try:
+            wikifile_url = result["upload"]["imageinfo"]["descriptionurl"]
+            file_link = result["upload"]["imageinfo"]["url"]
+        except KeyError:
+            upload_result = result.get("upload", {}).get("result", "unknown")
+            logger.error("Upload response missing expected fields. Result: %s, Full response: %s",
+                         upload_result, result)
+            return {"success": False, "data": {}, "errors": ["Upload failed — unexpected response from wiki"]}
+
+        self.update_state(state='PROGRESS', meta={'current': 100, 'total': 100})
+
+        return {
+            "wikipage_url": wikifile_url,
+            "file_link": file_link
+        }
+
+    except requests.RequestException as e:
+        logger.error("Network error during async upload to %s: %s", tr_endpoint, e)
+        return {"success": False, "data": {}, "errors": [f"Network error: {str(e)}"]}
+    except Exception as e:
+        logger.error("Unexpected error in upload task: %s", e, exc_info=True)
+        return {"success": False, "data": {}, "errors": [f"Unexpected error: {str(e)}"]}
+    finally:
+        # Close file handle if opened
+        if file_handle is not None:
+            file_handle.close()
+        # Clean up temp file
+        cleanup_temp_file(file_path)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,126 @@
+import pytest
+import json
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+# Add project root to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+@pytest.fixture
+def app():
+    """Create a test Flask app with minimal config."""
+    # Create a minimal config.yaml for testing
+    import yaml
+    config = {
+        'ENV': 'dev',
+        'SECRET_KEY': 'test-secret-key',
+        'CONSUMER_KEY': 'test-consumer-key',
+        'CONSUMER_SECRET': 'test-consumer-secret',
+        'OAUTH_MWURI': 'https://meta.wikimedia.org/w',
+        'SESSION_COOKIE_SECURE': False,
+        'SESSION_REFRESH_EACH_REQUEST': False,
+        'PREFERRED_URL_SCHEME': 'https',
+        'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
+        'SQLALCHEMY_TRACK_MODIFICATIONS': False,
+    }
+
+    config_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'config.yaml')
+    config_existed = os.path.exists(config_path)
+
+    if not config_existed:
+        with open(config_path, 'w') as f:
+            yaml.dump(config, f)
+
+    from app import app as flask_app
+    flask_app.config['TESTING'] = True
+
+    yield flask_app
+
+    if not config_existed:
+        os.remove(config_path)
+
+
+@pytest.fixture
+def client(app):
+    """Create a test client."""
+    return app.test_client()
+
+
+class TestUploadRoute:
+    """Tests for the /api/upload endpoint."""
+
+    def test_rejects_missing_json(self, client):
+        """Upload returns 400 when no JSON payload is provided."""
+        response = client.post('/api/upload', content_type='application/json')
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data["success"] is False
+
+    def test_rejects_missing_src_url(self, client):
+        """Upload returns 400 when srcUrl is missing."""
+        response = client.post('/api/upload',
+                               data=json.dumps({"trproject": "wikipedia"}),
+                               content_type='application/json')
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data["success"] is False
+        assert any("srcUrl" in err for err in data["errors"])
+
+    def test_rejects_invalid_url_format(self, client):
+        """Upload returns 400 when srcUrl doesn't match expected wiki URL pattern."""
+        response = client.post('/api/upload',
+                               data=json.dumps({"srcUrl": "https://example.com/not-a-wiki"}),
+                               content_type='application/json')
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data["success"] is False
+        assert any("Invalid source URL" in err for err in data["errors"])
+
+    @patch('app.download_image', return_value=None)
+    def test_returns_400_on_download_failure(self, mock_download, client):
+        """Upload returns 400 when downloading the source file fails."""
+        response = client.post('/api/upload',
+                               data=json.dumps({
+                                   "srcUrl": "https://commons.wikimedia.org/wiki/File:Test.jpg",
+                                   "trproject": "wikipedia",
+                                   "trlang": "en",
+                                   "trfilename": "Test"
+                               }),
+                               content_type='application/json')
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data["success"] is False
+        assert any("download" in err.lower() for err in data["errors"])
+
+    @patch('app.authenticated_session', return_value=None)
+    @patch('app.cleanup_temp_file')
+    @patch('app.download_image', return_value="test_file.jpg")
+    def test_returns_401_when_not_authenticated(self, mock_download, mock_cleanup, mock_auth, client):
+        """Upload returns 401 when user is not authenticated."""
+        response = client.post('/api/upload',
+                               data=json.dumps({
+                                   "srcUrl": "https://commons.wikimedia.org/wiki/File:Test.jpg",
+                                   "trproject": "wikipedia",
+                                   "trlang": "en",
+                                   "trfilename": "Test"
+                               }),
+                               content_type='application/json')
+        assert response.status_code == 401
+        data = response.get_json()
+        assert data["success"] is False
+        assert any("authenticated" in err.lower() or "log in" in err.lower() for err in data["errors"])
+
+    @patch('app.cleanup_temp_file')
+    @patch('app.download_image', return_value="test_file.jpg")
+    def test_returns_400_when_target_fields_missing(self, mock_download, mock_cleanup, client):
+        """Upload returns 400 when target project/language/filename are missing."""
+        response = client.post('/api/upload',
+                               data=json.dumps({
+                                   "srcUrl": "https://commons.wikimedia.org/wiki/File:Test.jpg"
+                               }),
+                               content_type='application/json')
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data["success"] is False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,201 @@
+import pytest
+import json
+import os
+import sys
+from unittest.mock import patch, MagicMock, mock_open
+
+# Add project root to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class TestDownloadImage:
+    """Tests for utils.download_image()"""
+
+    @patch('utils.requests.get')
+    def test_returns_none_on_api_failure(self, mock_get):
+        """download_image returns None when the source wiki API call fails."""
+        import requests as req
+        mock_get.side_effect = req.RequestException("Connection error")
+
+        from utils import download_image
+        result = download_image("wikimedia", "commons", "File:Test.jpg")
+        assert result is None
+
+    @patch('utils.requests.get')
+    def test_returns_none_on_missing_imageinfo(self, mock_get):
+        """download_image returns None when imageinfo key is missing from API response."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "query": {"pages": {"-1": {"title": "File:Test.jpg", "missing": ""}}}
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        from utils import download_image
+        result = download_image("wikimedia", "commons", "File:Test.jpg")
+        assert result is None
+
+    @patch('utils.os.makedirs')
+    @patch('builtins.open', mock_open())
+    @patch('utils.requests.get')
+    def test_handles_non_image_content_type(self, mock_get, mock_makedirs):
+        """download_image handles non-image content-type gracefully."""
+        # First call: API response with image URL
+        api_response = MagicMock()
+        api_response.json.return_value = {
+            "query": {"pages": {"123": {"imageinfo": [{"url": "https://example.com/test.jpg"}]}}}
+        }
+        api_response.raise_for_status = MagicMock()
+
+        # Second call: image download with non-image content-type
+        download_response = MagicMock()
+        download_response.headers = {'content-type': 'text/html'}
+        download_response.content = b'<html>error</html>'
+        download_response.raise_for_status = MagicMock()
+
+        mock_get.side_effect = [api_response, download_response]
+
+        from utils import download_image
+        result = download_image("wikimedia", "commons", "File:Test.jpg")
+        # Should still return a filename (fallback to URL extension)
+        assert result is not None
+        assert result.endswith('.jpg')
+
+    @patch('utils.requests.get')
+    def test_returns_none_on_malformed_json(self, mock_get):
+        """download_image returns None when API returns unexpected JSON structure."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"error": {"code": "badtitle"}}
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        from utils import download_image
+        result = download_image("wikimedia", "commons", "File:Test.jpg")
+        assert result is None
+
+
+class TestProcessUpload:
+    """Tests for utils.process_upload()"""
+
+    @patch('utils.requests.post')
+    @patch('utils.requests.get')
+    def test_returns_none_on_csrf_failure(self, mock_get, mock_post):
+        """process_upload returns None when CSRF token retrieval fails."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"error": {"code": "badtoken"}}
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        from utils import process_upload
+        # Create a temp file for the test
+        os.makedirs("temp_images", exist_ok=True)
+        test_path = "temp_images/test_csrf_fail.jpg"
+        with open(test_path, 'wb') as f:
+            f.write(b'fake image data')
+
+        result = process_upload(test_path, "TestFile", "jpg", "https://en.wikipedia.org/w/api.php", MagicMock())
+        assert result is None
+
+    @patch('utils.requests.post')
+    @patch('utils.requests.get')
+    def test_returns_none_on_mediawiki_error(self, mock_get, mock_post):
+        """process_upload returns None when MediaWiki API returns an error response."""
+        # CSRF token response (success)
+        csrf_response = MagicMock()
+        csrf_response.json.return_value = {"query": {"tokens": {"csrftoken": "abc123+\\"}}}
+        csrf_response.raise_for_status = MagicMock()
+        mock_get.return_value = csrf_response
+
+        # Upload response (MediaWiki error)
+        upload_response = MagicMock()
+        upload_response.json.return_value = {
+            "error": {"code": "mustbeloggedin", "info": "You must be logged in to upload files."}
+        }
+        upload_response.raise_for_status = MagicMock()
+        mock_post.return_value = upload_response
+
+        from utils import process_upload
+        os.makedirs("temp_images", exist_ok=True)
+        test_path = "temp_images/test_mw_error.jpg"
+        with open(test_path, 'wb') as f:
+            f.write(b'fake image data')
+
+        result = process_upload(test_path, "TestFile", "jpg", "https://en.wikipedia.org/w/api.php", MagicMock())
+        assert result is None
+
+    @patch('utils.requests.post')
+    @patch('utils.requests.get')
+    def test_successful_upload_returns_urls(self, mock_get, mock_post):
+        """process_upload returns file URLs on success."""
+        # CSRF token response
+        csrf_response = MagicMock()
+        csrf_response.json.return_value = {"query": {"tokens": {"csrftoken": "abc123+\\"}}}
+        csrf_response.raise_for_status = MagicMock()
+        mock_get.return_value = csrf_response
+
+        # Upload response (success)
+        upload_response = MagicMock()
+        upload_response.json.return_value = {
+            "upload": {
+                "result": "Success",
+                "imageinfo": {
+                    "descriptionurl": "https://en.wikipedia.org/wiki/File:Test.jpg",
+                    "url": "https://upload.wikimedia.org/wikipedia/en/Test.jpg"
+                }
+            }
+        }
+        upload_response.raise_for_status = MagicMock()
+        mock_post.return_value = upload_response
+
+        from utils import process_upload
+        os.makedirs("temp_images", exist_ok=True)
+        test_path = "temp_images/test_success.jpg"
+        with open(test_path, 'wb') as f:
+            f.write(b'fake image data')
+
+        result = process_upload(test_path, "TestFile", "jpg", "https://en.wikipedia.org/w/api.php", MagicMock())
+        assert result is not None
+        assert "wikipage_url" in result
+        assert "file_link" in result
+
+    @patch('utils.requests.get')
+    def test_returns_none_on_network_error(self, mock_get):
+        """process_upload returns None on network error."""
+        import requests
+        mock_get.side_effect = requests.RequestException("Connection refused")
+
+        from utils import process_upload
+        os.makedirs("temp_images", exist_ok=True)
+        test_path = "temp_images/test_network.jpg"
+        with open(test_path, 'wb') as f:
+            f.write(b'fake image data')
+
+        result = process_upload(test_path, "TestFile", "jpg", "https://en.wikipedia.org/w/api.php", MagicMock())
+        assert result is None
+
+
+class TestCleanupTempFile:
+    """Tests for utils.cleanup_temp_file()"""
+
+    def test_removes_existing_file(self):
+        """cleanup_temp_file removes an existing temp file."""
+        os.makedirs("temp_images", exist_ok=True)
+        test_path = "temp_images/test_cleanup.jpg"
+        with open(test_path, 'wb') as f:
+            f.write(b'test data')
+
+        from utils import cleanup_temp_file
+        cleanup_temp_file(test_path)
+        assert not os.path.exists(test_path)
+
+    def test_handles_nonexistent_file(self):
+        """cleanup_temp_file handles nonexistent files gracefully."""
+        from utils import cleanup_temp_file
+        # Should not raise
+        cleanup_temp_file("temp_images/nonexistent_file.jpg")
+
+    def test_handles_none_path(self):
+        """cleanup_temp_file handles None path gracefully."""
+        from utils import cleanup_temp_file
+        # Should not raise
+        cleanup_temp_file(None)

--- a/utils.py
+++ b/utils.py
@@ -1,10 +1,16 @@
 import datetime
 import requests
 import mwparserfromhell
+import os
+import logging
 from templatelist import TEMPLATES
 
+logger = logging.getLogger(__name__)
+
+
 def download_image(src_project, src_lang, src_filename):
-    src_endpoint = "https://"+ src_lang + "." + src_project + ".org/w/api.php"
+    """Download an image from a source wiki. Returns the local filename or None on failure."""
+    src_endpoint = "https://" + src_lang + "." + src_project + ".org/w/api.php"
 
     param = {
         "action": "query",
@@ -15,64 +21,143 @@ def download_image(src_project, src_lang, src_filename):
         "iilocalonly": 1
     }
 
-    page = requests.get(url=src_endpoint, params=param).json()['query']['pages']
-
     try:
-        image_url = list (page.values()) [0]["imageinfo"][0]["url"]
-    except KeyError:
+        response = requests.get(url=src_endpoint, params=param)
+        response.raise_for_status()
+        data = response.json()
+
+        # Validate the API response structure
+        if "query" not in data or "pages" not in data["query"]:
+            logger.error("Unexpected API response structure from %s: %s", src_endpoint, data)
+            return None
+
+        page = data['query']['pages']
+        image_url = list(page.values())[0]["imageinfo"][0]["url"]
+    except (KeyError, IndexError) as e:
+        logger.error("Could not extract image URL from source wiki: %s", e)
+        return None
+    except requests.RequestException as e:
+        logger.error("Failed to fetch image info from %s: %s", src_endpoint, e)
         return None
 
     # Create a unique file name based on time
     current_time = str(datetime.datetime.now())
-    get_filename = current_time.replace(':', '_')
-    get_filename = get_filename.replace(' ', '_')
+    get_filename = current_time.replace(':', '_').replace(' ', '_')
 
-    # Download the Image File
-    r = requests.get(image_url, allow_redirects=True)
-    filename = get_filename + "." + r.headers.get('content-type').replace('image/', '')
-    open("temp_images/" + filename, 'wb').write(r.content)
+    try:
+        r = requests.get(image_url, allow_redirects=True)
+        r.raise_for_status()
 
-    return filename
+        # Validate content-type header
+        content_type = r.headers.get('content-type', '')
+        if 'image/' in content_type:
+            ext = content_type.split('image/')[-1].split(';')[0]  # handle "image/jpeg; charset=..."
+        else:
+            # Fallback: extract extension from the original URL
+            ext = image_url.rsplit('.', 1)[-1] if '.' in image_url else 'bin'
+            logger.warning("Non-image content-type '%s' received, falling back to extension '%s'", content_type, ext)
+
+        filename = get_filename + "." + ext
+        filepath = os.path.join("temp_images", filename)
+
+        # Ensure temp_images directory exists
+        os.makedirs("temp_images", exist_ok=True)
+
+        with open(filepath, 'wb') as f:
+            f.write(r.content)
+
+        return filename
+    except requests.RequestException as e:
+        logger.error("Failed to download image from %s: %s", image_url, e)
+        return None
+    except OSError as e:
+        logger.error("Failed to save image file: %s", e)
+        return None
 
 
 def process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses):
-    # API Parameter to get CSRF Token
-    csrf_param = {
-        "action": "query",
-        "meta": "tokens",
-        "format": "json"
-    }
-
-    response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses)
-    csrf_token = response.json()["query"]["tokens"]["csrftoken"]
-
-    # API Parameter to upload the file
-    upload_param = {
-        "action": "upload",
-        "filename": tr_filename + "." + src_fileext,
-        "format": "json",
-        "token": csrf_token,
-        "ignorewarnings": 1
-    }
-
-    # Read the file for POST request
-    file = {
-        'file': open(file_path, 'rb')
-    }
-
-    response = requests.post(url=tr_endpoint, files=file, data=upload_param, auth=ses).json()
-
-    # Try block to get Link and URL
+    """Upload a file to the target wiki. Returns a result dict or None on failure."""
+    file_handle = None
     try:
-        wikifile_url = response["upload"]["imageinfo"]["descriptionurl"]
-        file_link = response["upload"]["imageinfo"]["url"]
-    except KeyError:
-        return None
+        # API Parameter to get CSRF Token
+        csrf_param = {
+            "action": "query",
+            "meta": "tokens",
+            "format": "json"
+        }
 
-    return {
-        "wikipage_url": wikifile_url,
-        "file_link": file_link
-    }
+        response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses)
+        response.raise_for_status()
+        token_data = response.json()
+
+        # Validate CSRF token response
+        try:
+            csrf_token = token_data["query"]["tokens"]["csrftoken"]
+        except KeyError:
+            logger.error("Failed to retrieve CSRF token from %s. Response: %s", tr_endpoint, token_data)
+            return None
+
+        # API Parameter to upload the file
+        upload_param = {
+            "action": "upload",
+            "filename": tr_filename + "." + src_fileext,
+            "format": "json",
+            "token": csrf_token,
+            "ignorewarnings": 1
+        }
+
+        # Read the file for POST request
+        file_handle = open(file_path, 'rb')
+        file = {'file': file_handle}
+
+        response = requests.post(url=tr_endpoint, files=file, data=upload_param, auth=ses)
+        response.raise_for_status()
+        result = response.json()
+
+        # Check for MediaWiki API-level error
+        if "error" in result:
+            error_code = result["error"].get("code", "unknown")
+            error_info = result["error"].get("info", "No details provided")
+            logger.error("MediaWiki upload error: [%s] %s", error_code, error_info)
+            return None
+
+        # Try block to get Link and URL
+        try:
+            wikifile_url = result["upload"]["imageinfo"]["descriptionurl"]
+            file_link = result["upload"]["imageinfo"]["url"]
+        except KeyError:
+            upload_result = result.get("upload", {}).get("result", "unknown")
+            logger.error("Upload response missing expected fields. Upload result: %s, Full response: %s",
+                         upload_result, result)
+            return None
+
+        return {
+            "wikipage_url": wikifile_url,
+            "file_link": file_link
+        }
+
+    except requests.RequestException as e:
+        logger.error("Network error during upload to %s: %s", tr_endpoint, e)
+        return None
+    except Exception as e:
+        logger.error("Unexpected error during upload: %s", e)
+        return None
+    finally:
+        # Close file handle if opened
+        if file_handle is not None:
+            file_handle.close()
+        # Clean up temp file
+        cleanup_temp_file(file_path)
+
+
+def cleanup_temp_file(file_path):
+    """Safely remove a temporary file."""
+    try:
+        if file_path and os.path.exists(file_path):
+            os.remove(file_path)
+            logger.info("Cleaned up temp file: %s", file_path)
+    except OSError as e:
+        logger.warning("Failed to clean up temp file %s: %s", file_path, e)
 
 
 def get_localized_wikitext(wikitext, src_endpoint, target_lang):


### PR DESCRIPTION
## 🐛 Issue
Fixes #40 
##  Changes Made

### 1. Improved /api/upload route (app.py)
- Added validation for input JSON, `srcUrl`, and `target`
- Return proper `401 Unauthorized` for unauthenticated users
- Wrapped entire route in try/except to prevent crashes
- Return structured JSON error responses instead of raw HTML 500
- Used `request.get_json(silent=True)` to safely handle empty payloads

### 2. Hardened download_image() (utils.py)
- Validated API response before accessing keys
- Gracefully handled non-image content types
- Added try/except for network and file I/O errors
---
### 3. Improved process_upload() (utils.py)
- Validated CSRF token response before usage
- Handled MediaWiki API errors properly
- Ensured file handles are closed using `finally`
- Cleaned up temporary files after upload (success/failure)
---
### 4. Improved upload_image_task() (tasks.py)
- Added same validation logic as synchronous upload flow
- Returned structured error responses instead of crashing
- Ensured temp file cleanup in `finally` block
---
### 5. Utility Addition
- Added `cleanup_temp_file()` helper for safe file cleanup
---
##  Result
- Prevents backend crashes
- Eliminates raw 500 responses
- Provides consistent, structured error handling
- Improves stability of upload pipeline
---
##  Testing
- Tested upload with valid and invalid inputs
- Verified proper error responses instead of 500 crashes
- Confirmed temp file cleanup in all cases
