### PR TITLE
Fix: Prevent temp file leaks using context managers and try-finally blocks (T415717)

### DIFF
--- a/app.py
+++ b/app.py
@@ -91,18 +91,23 @@ def upload():
             file_size = os.path.getsize(file_path)
 
             if file_size < 50 * 1024 * 1024:  # 50 MB
-                # Process synchronously
-                resp = process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses)
-                if resp is None:
-                    return jsonify({"success": False, "data": {}, "errors": ["Upload failed"]}), 500
+                try:
+                    # Process synchronously
+                    resp = process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses)
+                    if resp is None:
+                        return jsonify({"success": False, "data": {}, "errors": ["Upload failed"]}), 500
 
-                resp["source"] = src_url
+                    resp["source"] = src_url
 
-                return jsonify({
-                    "success": True,
-                    "data": resp,
-                    "errors": []
-                }), 200
+                    return jsonify({
+                        "success": True,
+                        "data": resp,
+                        "errors": []
+                    }), 200
+                finally:
+                    # IRONCLAD GUARANTEE: Always delete the file!
+                    if os.path.exists(file_path):
+                        os.remove(file_path)
             else:
                 # Process asynchronously using Celery
                 OAuthObj = {

--- a/tasks.py
+++ b/tasks.py
@@ -5,54 +5,57 @@ import os
 
 @app.task(bind=True)
 def upload_image_task(self, file_path, tr_filename, src_fileext, tr_endpoint, OAuthObj):
-    ses = requests_oauthlib.OAuth1(
-        client_key=OAuthObj["consumer_key"],
-        client_secret= OAuthObj["consumer_secret"],
-        resource_owner_key=OAuthObj["key"],
-        resource_owner_secret=OAuthObj["secret"]
-    )
-    self.update_state(state='PROGRESS', meta={'current': 0, 'total': 100})
-    
-    # API Parameter to get CSRF Token
-    csrf_param = {
-        "action": "query",
-        "meta": "tokens",
-        "format": "json"
-    }
-
-    response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses)
-    csrf_token = response.json()["query"]["tokens"]["csrftoken"]
-
-    self.update_state(state='PROGRESS', meta={'current': 25, 'total': 100})
-
-    # API Parameter to upload the file
-    upload_param = {
-        "action": "upload",
-        "filename": tr_filename + "." + src_fileext,
-        "format": "json",
-        "token": csrf_token,
-        "ignorewarnings": 1
-    }
-
-    # Read the file for POST request
-    file = {
-        'file': open(file_path, 'rb')
-    }
-
-    response = requests.post(url=tr_endpoint, files=file, data=upload_param, auth=ses).json()
-
-    self.update_state(state='PROGRESS', meta={'current': 75, 'total': 100})
-
-    # Try block to get Link and URL
     try:
-        wikifile_url = response["upload"]["imageinfo"]["descriptionurl"]
-        file_link = response["upload"]["imageinfo"]["url"]
-    except KeyError:
-        return {"success": False, "data": {}, "errors": ["Upload failed"]}
+        ses = requests_oauthlib.OAuth1(
+            client_key=OAuthObj["consumer_key"],
+            client_secret= OAuthObj["consumer_secret"],
+            resource_owner_key=OAuthObj["key"],
+            resource_owner_secret=OAuthObj["secret"]
+        )
+        self.update_state(state='PROGRESS', meta={'current': 0, 'total': 100})
+        
+        # API Parameter to get CSRF Token
+        csrf_param = {
+            "action": "query",
+            "meta": "tokens",
+            "format": "json"
+        }
 
-    self.update_state(state='PROGRESS', meta={'current': 100, 'total': 100})
+        response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses)
+        csrf_token = response.json()["query"]["tokens"]["csrftoken"]
 
-    return {
-        "wikipage_url": wikifile_url,
-        "file_link": file_link
-    }
+        self.update_state(state='PROGRESS', meta={'current': 25, 'total': 100})
+
+        # API Parameter to upload the file
+        upload_param = {
+            "action": "upload",
+            "filename": tr_filename + "." + src_fileext,
+            "format": "json",
+            "token": csrf_token,
+            "ignorewarnings": 1
+        }
+
+        # Use 'with' to fix the file handle leak
+        with open(file_path, 'rb') as f:
+            file_data = {'file': f}
+            response = requests.post(url=tr_endpoint, files=file_data, data=upload_param, auth=ses).json()
+
+        self.update_state(state='PROGRESS', meta={'current': 75, 'total': 100})
+
+        # Try block to get Link and URL
+        try:
+            wikifile_url = response["upload"]["imageinfo"]["descriptionurl"]
+            file_link = response["upload"]["imageinfo"]["url"]
+        except KeyError:
+            return {"success": False, "data": {}, "errors": ["Upload failed"]}
+
+        self.update_state(state='PROGRESS', meta={'current': 100, 'total': 100})
+
+        return {
+            "wikipage_url": wikifile_url,
+            "file_link": file_link
+        }
+    finally:
+        # Guarantee cleanup for Celery tasks
+        if os.path.exists(file_path):
+            os.remove(file_path)

--- a/utils.py
+++ b/utils.py
@@ -30,7 +30,7 @@ def download_image(src_project, src_lang, src_filename):
     # Download the Image File
     r = requests.get(image_url, allow_redirects=True)
     filename = get_filename + "." + r.headers.get('content-type').replace('image/', '')
-    open("temp_images/" + filename, 'wb').write(r.content)
+    with open("temp_images/" + filename, 'wb') as f: f.write(r.content)
 
     return filename
 
@@ -56,12 +56,10 @@ def process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses):
     }
 
     # Read the file for POST request
-    file = {
-        'file': open(file_path, 'rb')
-    }
-
-    response = requests.post(url=tr_endpoint, files=file, data=upload_param, auth=ses).json()
-
+    # Use 'with' to automatically close the file handle after the request
+    with open(file_path, 'rb') as f:
+        file_data = {'file': f}
+        response = requests.post(url=tr_endpoint, files=file_data, data=upload_param, auth=ses).json()
     # Try block to get Link and URL
     try:
         wikifile_url = response["upload"]["imageinfo"]["descriptionurl"]


### PR DESCRIPTION
### Description
This PR addresses the resource leaks and orphaned temporary file issues outlined in Phabricator task T415717.

### Changes made
* **Fixed File Handle Leaks:** Replaced bare `open(file, 'rb')` calls in `utils.py` and `tasks.py` with `with open(...)` context managers to guarantee file handles are safely closed by Python immediately after the `requests.post` API call finishes.
* **Synchronous Cleanup (`app.py`):** Wrapped the standard file processing route in a `try...finally` block, ensuring `os.remove(file_path)` executes even if the `process_upload` function fails or the target wiki API returns an unexpected error.
* **Asynchronous Cleanup (`tasks.py`):** Added a `finally` block to the `upload_image_task` Celery background worker to guarantee massive files (>50MB) are securely deleted from the server's hard drive upon success, failure, or timeout.

### Testing Performed
* Verified that a successful file transfer successfully clears the `temp_images/` directory.
* Conducted stress testing by intentionally triggering a backend API crash (simulating a 404/502 error from the Wikimedia API) to ensure the `finally` block successfully intercepts the crash and deletes the orphaned file before the request drops.

### Bug Tracker
Resolves T415717