### PR TITLE
Fix: Handle API crashes for Commons files (#40) and missing/502 target files (#42)

### DIFF
--- a/app.py
+++ b/app.py
@@ -61,12 +61,22 @@ def index():
 
 
 @app.route('/api/upload', methods=['POST'])
+@app.route('/api/upload', methods=['POST'])
 def upload():
     if request.method == 'POST':
         data = request.get_json()
         src_url = urllib.parse.unquote(data.get('srcUrl'))
-        match = re.findall(r"(\w+)\.(\w+)\.org/wiki/", src_url)
+        
+        # Issue #40: Prevent transfers from Wikimedia Commons since they are universally shared
+        if "commons.wikimedia.org" in src_url.lower():
+            return jsonify({
+                "success": False, 
+                "data": {}, 
+                "errors": ["Files on Wikimedia Commons are already available to all wikis. No transfer is needed!"]
+            }), 400
 
+        match = re.findall(r"(\w+)\.(\w+)\.org/wiki/", src_url)
+        
         src_project = match[0][1]
         src_lang = match[0][0]
         src_filename = src_url.split('/')[-1]

--- a/utils.py
+++ b/utils.py
@@ -15,13 +15,15 @@ def download_image(src_project, src_lang, src_filename):
         "iilocalonly": 1
     }
 
-    page = requests.get(url=src_endpoint, params=param).json()['query']['pages']
-
+    response = requests.get(url=src_endpoint, params=param)
+    
+    # Safely attempt to parse JSON to prevent crashes on 502/404 HTML responses (Issue #42)
     try:
-        image_url = list (page.values()) [0]["imageinfo"][0]["url"]
-    except KeyError:
+        page = response.json().get('query', {}).get('pages', {})
+        image_url = list(page.values())[0]["imageinfo"][0]["url"]
+    except (requests.exceptions.JSONDecodeError, KeyError, IndexError):
         return None
-
+        
     # Create a unique file name based on time
     current_time = str(datetime.datetime.now())
     get_filename = current_time.replace(':', '_')


### PR DESCRIPTION
### Description
This PR addresses two related backend API crash vulnerabilities outlined in Issue #40 and Issue #42.

### Part 1: The Wikimedia Commons Fix (Issue #40)
* **Added Early Validation:** Inserted a validation check at the top of the `upload()` route in `app.py`.
* **Safe Rejection:** If the `src_url` contains `commons.wikimedia.org`, the backend now immediately rejects the request and returns a `400` response with an educational error message ("Files on Wikimedia Commons are already available to all wikis").
* **Resource Optimization:** This prevents the server from wasting bandwidth downloading files that are already universally accessible, and bypasses the subsequent API processing errors that were causing the backend to fail.

### Part 2: The HTML/JSON Crash Fix (Issue #42)
* **Graceful Exception Handling:** Updated the `download_image()` function in `utils.py` to handle exceptions safely during `response.json()` parsing.
* **Caught Decode Errors:** Wrapped the JSON extraction in a `try...except` block that explicitly catches `requests.exceptions.JSONDecodeError` (alongside `KeyError` and `IndexError`).
* **Prevented Tracebacks:** If the API fails to return valid JSON (e.g., when a movie poster upload is rejected by an abuse filter or a file is missing/returns a 404/502 HTML page), the function now cleanly returns `None` instead of throwing a fatal traceback. This allows the frontend to display a standard upload failure state.

### Fixes
Resolves #40
Resolves #42