### PR TITLE
fix: add error handling and temp file cleanup in upload task

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -2,30 +2,37 @@ from celeryWorker import app
 import requests
 import requests_oauthlib
 import os
+import logging
+
+logger = logging.getLogger(__name__)
 
 @app.task(bind=True)
 def upload_image_task(self, file_path, tr_filename, src_fileext, tr_endpoint, OAuthObj):
     ses = requests_oauthlib.OAuth1(
         client_key=OAuthObj["consumer_key"],
-        client_secret= OAuthObj["consumer_secret"],
+        client_secret=OAuthObj["consumer_secret"],
         resource_owner_key=OAuthObj["key"],
         resource_owner_secret=OAuthObj["secret"]
     )
     self.update_state(state='PROGRESS', meta={'current': 0, 'total': 100})
-    
-    # API Parameter to get CSRF Token
+
+    # Get CSRF Token
     csrf_param = {
         "action": "query",
         "meta": "tokens",
         "format": "json"
     }
-
-    response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses)
-    csrf_token = response.json()["query"]["tokens"]["csrftoken"]
+    try:
+        response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses, timeout=30)
+        response.raise_for_status()
+        csrf_token = response.json()["query"]["tokens"]["csrftoken"]
+    except Exception as e:
+        logger.error(f"Failed to get CSRF token: {e}")
+        return {"success": False, "data": {}, "errors": [f"Failed to get CSRF token: {str(e)}"]}
 
     self.update_state(state='PROGRESS', meta={'current': 25, 'total': 100})
 
-    # API Parameter to upload the file
+    # Upload file
     upload_param = {
         "action": "upload",
         "filename": tr_filename + "." + src_fileext,
@@ -34,24 +41,35 @@ def upload_image_task(self, file_path, tr_filename, src_fileext, tr_endpoint, OA
         "ignorewarnings": 1
     }
 
-    # Read the file for POST request
-    file = {
-        'file': open(file_path, 'rb')
-    }
-
-    response = requests.post(url=tr_endpoint, files=file, data=upload_param, auth=ses).json()
+    try:
+        with open(file_path, 'rb') as f:  # ✅ File automatically close hogi
+            file = {'file': f}
+            response = requests.post(
+                url=tr_endpoint,
+                files=file,
+                data=upload_param,
+                auth=ses,
+                timeout=120
+            ).json()
+    except Exception as e:
+        logger.error(f"Upload request failed: {e}")
+        return {"success": False, "data": {}, "errors": [f"Upload failed: {str(e)}"]}
+    finally:
+        # ✅ Temp file cleanup - hamesha delete hoga
+        if os.path.exists(file_path):
+            os.remove(file_path)
+            logger.info(f"Temp file cleaned up: {file_path}")
 
     self.update_state(state='PROGRESS', meta={'current': 75, 'total': 100})
 
-    # Try block to get Link and URL
     try:
         wikifile_url = response["upload"]["imageinfo"]["descriptionurl"]
         file_link = response["upload"]["imageinfo"]["url"]
     except KeyError:
-        return {"success": False, "data": {}, "errors": ["Upload failed"]}
+        logger.error(f"Unexpected response: {response}")
+        return {"success": False, "data": {}, "errors": ["Upload failed - unexpected response"]}
 
     self.update_state(state='PROGRESS', meta={'current': 100, 'total': 100})
-
     return {
         "wikipage_url": wikifile_url,
         "file_link": file_link


### PR DESCRIPTION
Fixes T415715 and T415717

Changes made:
- Added try/except blocks for CSRF token fetch and file upload
- Added timeout to all requests (30s for API, 120s for upload)
- Used `with` statement so file handle closes automatically
- Added `finally` block to always delete temp files after upload
- Added logging for errors and cleanup events