### PR TITLE
Improve: Add timeout to API requests to prevent hanging calls

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -3,8 +3,9 @@ import requests
 import mwparserfromhell
 from templatelist import TEMPLATES
 
+
 def download_image(src_project, src_lang, src_filename):
-    src_endpoint = "https://"+ src_lang + "." + src_project + ".org/w/api.php"
+    src_endpoint = "https://" + src_lang + "." + src_project + ".org/w/api.php"
 
     param = {
         "action": "query",
@@ -15,38 +16,33 @@ def download_image(src_project, src_lang, src_filename):
         "iilocalonly": 1
     }
 
-    page = requests.get(url=src_endpoint, params=param).json()['query']['pages']
+    page = requests.get(url=src_endpoint, params=param, timeout=10).json()['query']['pages']
 
     try:
-        image_url = list (page.values()) [0]["imageinfo"][0]["url"]
+        image_url = list(page.values())[0]["imageinfo"][0]["url"]
     except KeyError:
         return None
 
-    # Create a unique file name based on time
-    current_time = str(datetime.datetime.now())
-    get_filename = current_time.replace(':', '_')
-    get_filename = get_filename.replace(' ', '_')
+    current_time = str(datetime.datetime.now()).replace(':', '_').replace(' ', '_')
 
-    # Download the Image File
-    r = requests.get(image_url, allow_redirects=True)
-    filename = get_filename + "." + r.headers.get('content-type').replace('image/', '')
+    r = requests.get(image_url, allow_redirects=True, timeout=10)
+    filename = current_time + "." + r.headers.get('content-type').replace('image/', '')
+
     open("temp_images/" + filename, 'wb').write(r.content)
 
     return filename
 
 
 def process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses):
-    # API Parameter to get CSRF Token
     csrf_param = {
         "action": "query",
         "meta": "tokens",
         "format": "json"
     }
 
-    response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses)
+    response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses, timeout=10)
     csrf_token = response.json()["query"]["tokens"]["csrftoken"]
 
-    # API Parameter to upload the file
     upload_param = {
         "action": "upload",
         "filename": tr_filename + "." + src_fileext,
@@ -55,14 +51,18 @@ def process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses):
         "ignorewarnings": 1
     }
 
-    # Read the file for POST request
     file = {
         'file': open(file_path, 'rb')
     }
 
-    response = requests.post(url=tr_endpoint, files=file, data=upload_param, auth=ses).json()
+    response = requests.post(
+        url=tr_endpoint,
+        files=file,
+        data=upload_param,
+        auth=ses,
+        timeout=10
+    ).json()
 
-    # Try block to get Link and URL
     try:
         wikifile_url = response["upload"]["imageinfo"]["descriptionurl"]
         file_link = response["upload"]["imageinfo"]["url"]
@@ -94,18 +94,21 @@ def get_localized_wikitext(wikitext, src_endpoint, target_lang):
                     }
 
                     try:
-                        response = requests.get(url=src_endpoint, params=lang_param)
+                        response = requests.get(url=src_endpoint, params=lang_param, timeout=10)
                         response.raise_for_status()
+
                         langlinks = response.json()["query"]["pages"][0]["langlinks"]
 
                         for langlink in langlinks:
                             if langlink["lang"] == target_lang:
                                 template.add("Article", langlink["title"])
                                 break
+
                     except:
                         return str(wikicode)
 
     return str(wikicode)
+
 
 def getHeader():
     agent = 'Wikifile-transfer/1.0 (https://wikifile-transfer.toolforge.org; 0freerunning@gmail.com)'


### PR DESCRIPTION
Added timeout parameter to API requests to prevent potential hanging calls.

This ensures that the application does not wait indefinitely for responses from external APIs, improving reliability and stability.

This builds upon previous improvements related to API request handling.