### PR TITLE
feat: implement structured error handling and logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,13 @@ __pycache__/
 .idea/*
 .idea/
 venv/
+env
 
 temp_images/*
 !temp_images/.gitkeep
+
+# Application log files generated at runtime (see configure_logging in app.py)
+logs/*
+!logs/.gitkeep
+
 config.yaml

--- a/app.py
+++ b/app.py
@@ -1,158 +1,228 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from flask import Flask, request, session, jsonify, render_template
-from flask_mwoauth import MWOAuth
-from flask_migrate import Migrate
-from utils import download_image, get_localized_wikitext, getHeader, process_upload
-from flask_cors import CORS
-import requests_oauthlib
-import requests
+"""
+app.py – Flask application entry point for Wikifile-Transfer.
+
+Responsibilities
+----------------
+* Bootstrap the Flask app, database, OAuth blueprint, and Celery connection.
+* Configure structured, rotating file-based logging (see ``configure_logging``).
+* Register centralised error handlers (see ``error_handlers.py``).
+* Define all HTTP API endpoints with consistent request validation and error
+  reporting using the custom exception hierarchy in ``exceptions.py``.
+"""
+
+import logging
 import os
-import yaml
 import re
 import urllib.parse
-from model import db, User
-import logging
-from celeryWorker import app as celery_app
-from tasks import upload_image_task
-from celery.result import AsyncResult
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
+import requests
+import requests_oauthlib
+import yaml
+from celery.result import AsyncResult
+from flask import Flask, jsonify, render_template, request, session
+from flask_cors import CORS
+from flask_migrate import Migrate
+from flask_mwoauth import MWOAuth
+
+from logging_config import configure_logging
+from celeryWorker import app as celery_app
+from error_handlers import register_error_handlers
+from exceptions import (
+    AuthenticationError,
+    DatabaseError,
+    DownloadError,
+    ExternalAPIError,
+    UploadError,
+    ValidationError,
+)
+from model import db, User
+from tasks import upload_image_task
+from utils import download_image, get_localized_wikitext, getHeader, process_upload
+
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Application factory
+# ---------------------------------------------------------------------------
 
 app = Flask(__name__)
 
-# Load configuration from YAML file
+# Load configuration from YAML file.
 __dir__ = os.path.dirname(__file__)
-app.config.update(yaml.safe_load(open(os.path.join(__dir__, 'config.yaml'))))
+app.config.update(yaml.safe_load(open(os.path.join(__dir__, "config.yaml"))))
 
 # Get variables
-ENV = app.config['ENV']
-BASE_URL = app.config['OAUTH_MWURI']
-API_ENDPOINT = BASE_URL + '/api.php'
-CONSUMER_KEY = app.config['CONSUMER_KEY']
-CONSUMER_SECRET = app.config['CONSUMER_SECRET']
+ENV = app.config["ENV"]
+BASE_URL = app.config["OAUTH_MWURI"]
+API_ENDPOINT = BASE_URL + "/api.php"
+CONSUMER_KEY = app.config["CONSUMER_KEY"]
+CONSUMER_SECRET = app.config["CONSUMER_SECRET"]
 
-# Enable CORS and Debugging in Dev mode
-if ENV == 'dev':
+# Enable CORS and debug mode in dev environment.
+if ENV == "dev":
     CORS(app, supports_credentials=True)
-    app.config['DEBUG'] = True
+    app.config["DEBUG"] = True
 
-# Create Database and Migration Object
+# Initialise structured logging now that DEBUG flag is known.
+configure_logging(app)
+
+# Create Database and Migration objects.
 db.init_app(app)
 migrate = Migrate(app, db)
 
-# Register blueprint to app
+# Register the MediaWiki OAuth blueprint.
 MW_OAUTH = MWOAuth(
     base_url=BASE_URL,
     consumer_key=CONSUMER_KEY,
     consumer_secret=CONSUMER_SECRET,
-    user_agent= getHeader()['User-Agent']
+    user_agent=getHeader()["User-Agent"],
 )
 app.register_blueprint(MW_OAUTH.bp)
 
+# Register centralised error handlers (see error_handlers.py).
+register_error_handlers(app)
 
-@app.route('/index', methods=['GET'])
+logger.info("Wikifile-Transfer application initialised (ENV=%s)", ENV)
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+@app.route("/index", methods=["GET"])
 @app.route("/")
 def index():
-    return render_template('index.html')
+    return render_template("index.html")
 
 
-@app.route('/api/upload', methods=['POST'])
+@app.route("/api/upload", methods=["POST"])
 def upload():
-    if request.method == 'POST':
-        data = request.get_json()
-        src_url = urllib.parse.unquote(data.get('srcUrl'))
-        match = re.findall(r"(\w+)\.(\w+)\.org/wiki/", src_url)
+    """
+    Trigger a file transfer from a source wiki to a target wiki.
 
-        src_project = match[0][1]
-        src_lang = match[0][0]
-        src_filename = src_url.split('/')[-1]
-        src_fileext = src_filename.split('.')[-1]
+    For files under 50 MB the upload is handled synchronously.
+    Larger files are handed off to a Celery worker and a ``task_id`` is
+    returned so the client can poll ``/api/task_status/<task_id>``.
+    """
+    # --- Parse and validate request body ------------------------------------
+    data = request.get_json()
+    if not data:
+        raise ValidationError("Request body must be JSON.")
 
-        # Downloading the source file and getting saved file name
+    src_url = data.get("srcUrl")
+    if not src_url:
+        raise ValidationError("Missing required field: 'srcUrl'.")
+    src_url = urllib.parse.unquote(src_url)
+
+    match = re.findall(r"(\w+)\.(\w+)\.org/wiki/", src_url)
+    if not match:
+        raise ValidationError(
+            "Could not parse source wiki from 'srcUrl'. "
+            "Expected format: https://<lang>.<project>.org/wiki/…"
+        )
+
+    src_lang = match[0][0]
+    src_project = match[0][1]
+    src_filename = src_url.split("/")[-1]
+    src_fileext = src_filename.split(".")[-1]
+
+    tr_project = data.get("trproject")
+    tr_lang = data.get("trlang")
+    tr_filename = data.get("trfilename")
+
+    if not all([tr_project, tr_lang, tr_filename]):
+        raise ValidationError(
+            "Missing one or more required fields: 'trproject', 'trlang', 'trfilename'."
+        )
+
+    tr_filename = urllib.parse.unquote(tr_filename)
+    tr_endpoint = f"https://{tr_lang}.{tr_project}.org/w/api.php"
+
+    # --- Authentication check -----------------------------------------------
+    ses = _authenticated_session()
+    if ses is None:
+        raise AuthenticationError()
+
+    # --- Download source file -----------------------------------------------
+    logger.info(
+        "Downloading source file '%s' from %s.%s", src_filename, src_lang, src_project
+    )
+    try:
         downloaded_filename = download_image(src_project, src_lang, src_filename)
+    except DownloadError as e:
+        # Translate the internal DownloadError into an HTTP 502 for the client.
+        raise ExternalAPIError(str(e)) from e
 
-        # Getting Target Details
-        tr_project = data.get('trproject')
-        tr_lang = data.get('trlang')
-        tr_filename = data.get('trfilename')
-        tr_filename = urllib.parse.unquote(tr_filename)
-        tr_endpoint = "https://" + tr_lang + "." + tr_project + ".org/w/api.php"
+    # --- Upload to target wiki ----------------------------------------------
+    file_path = "temp_images/" + downloaded_filename
+    file_size = os.path.getsize(file_path)
 
-        # Authenticate Session
-        ses = authenticated_session()
+    if file_size < 50 * 1024 * 1024:  # 50 MB – process synchronously
+        logger.info(
+            "Uploading '%s' synchronously to %s.%s", tr_filename, tr_lang, tr_project
+        )
+        # process_upload raises UploadError (HTTP 502) on any failure;
+        # no null-check needed – the exception bubbles up to the error handler.
+        resp = process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses)
+        resp["source"] = src_url
+        logger.info("Synchronous upload succeeded: %s", resp.get("wikipage_url"))
+        return jsonify({"success": True, "data": resp, "errors": []}), 200
 
-        # Check whether we have enough data or not
-        if None not in (downloaded_filename, tr_filename, src_fileext, ses):
-            file_path = 'temp_images/' + downloaded_filename
-            file_size = os.path.getsize(file_path)
-
-            if file_size < 50 * 1024 * 1024:  # 50 MB
-                # Process synchronously
-                resp = process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses)
-                if resp is None:
-                    return jsonify({"success": False, "data": {}, "errors": ["Upload failed"]}), 500
-
-                resp["source"] = src_url
-
-                return jsonify({
-                    "success": True,
-                    "data": resp,
-                    "errors": []
-                }), 200
-            else:
-                # Process asynchronously using Celery
-                OAuthObj = {
-                    "consumer_key": CONSUMER_KEY,
-                    "consumer_secret": CONSUMER_SECRET,
-                    "key": session['mwoauth_access_token']['key'],
-                    "secret": session['mwoauth_access_token']['secret']
-                }
-                task = upload_image_task.delay(file_path, tr_filename, src_fileext, tr_endpoint, OAuthObj)
-                return jsonify({"success": True, "task_id": task.id}), 202
-        else:
-            return jsonify({"success": False, "data": {}, "errors": ["Not enough data"]}), 400
     else:
-        return jsonify({"success": False, "data": {}, "errors": ["Invalid Request"]}), 400
+        # Large file – dispatch to Celery worker.
+        logger.info(
+            "File exceeds 50 MB (%d bytes); dispatching async task for '%s'",
+            file_size,
+            tr_filename,
+        )
+        oauth_obj = {
+            "consumer_key":    CONSUMER_KEY,
+            "consumer_secret": CONSUMER_SECRET,
+            "key":    session["mwoauth_access_token"]["key"],
+            "secret": session["mwoauth_access_token"]["secret"],
+        }
+        task = upload_image_task.delay(
+            file_path, tr_filename, src_fileext, tr_endpoint, oauth_obj
+        )
+        logger.info("Async upload task queued with id=%s", task.id)
+        return jsonify({"success": True, "data": {"task_id": task.id}, "errors": []}), 202
 
 
-@app.route('/api/preference', methods = ['GET', 'POST'])
+@app.route("/api/preference", methods=["GET", "POST"])
 def preference():
+    """Get or update the authenticated user's upload preferences."""
 
-    if request.method == 'GET':
-        user = db_user()
+    if request.method == "GET":
+        user = _db_user()
 
-        user_project = "wikipedia"
-        user_lang = "en"
-        skip_upload_selection = False
+        # Fall back to sensible defaults for unauthenticated / new users.
+        project = user.pref_project if user else "wikipedia"
+        lang    = user.pref_language if user else "en"
+        skip    = user.skip_upload_selection if user else False
 
-        if user is not None:
-            user_project = user.pref_project
-            user_lang = user.pref_language
-            skip_upload_selection = user.skip_upload_selection
-            
-        return jsonify(
-            {
-                "success": True,
-                "data": {
-                    "project": user_project,
-                    "lang": user_lang,
-                    "skip_upload_selection": skip_upload_selection
-                },
-                "error": []
-            }), 200
+        return jsonify({
+            "success": True,
+            "data": {
+                "project":              project,
+                "lang":                 lang,
+                "skip_upload_selection": skip,
+            },
+            "errors": [],
+        }), 200
 
-    elif request.method == 'POST':
-        # Get the data
+    elif request.method == "POST":
         data = request.get_json()
-        project = data.get('project')
-        lang = data.get('lang')
-        skip_upload_selection = data.get('skip_upload_selection')
+        if not data:
+            raise ValidationError("Request body must be JSON.")
 
-        # Add into database
+        project  = data.get("project")
+        lang     = data.get("lang")
+        skip     = data.get("skip_upload_selection")
+
         cur_username = MW_OAUTH.get_current_user(True)
         user = User.query.filter_by(username=cur_username).first()
 
@@ -161,46 +231,50 @@ def preference():
                 username=cur_username,
                 pref_language=lang,
                 pref_project=project,
-                skip_upload_selection=skip_upload_selection
+                skip_upload_selection=skip,
             )
             db.session.add(user)
         else:
-            user.pref_language = lang
-            user.pref_project = project
-            user.skip_upload_selection = skip_upload_selection
+            user.pref_language        = lang
+            user.pref_project         = project
+            user.skip_upload_selection = skip
 
         try:
             db.session.commit()
-            return jsonify({ "success": True, "data": {}, "errors": []}), 200
-        except:
+            logger.info("Preferences updated for user '%s'", cur_username)
+            return jsonify({"success": True, "data": {}, "errors": []}), 200
+        except Exception as e:
             db.session.rollback()
-            return jsonify({ "success": False, "data": {}, "errors": ["Database Error"]}), 500
+            raise DatabaseError(
+                f"Failed to save preferences for '{cur_username}'."
+            ) from e
 
     else:
-        return jsonify({ "success": False, "data": {}, "errors": ["Invalid Request"]}), 400
+        raise ValidationError("Method not allowed.")
 
 
-@app.route('/api/user_language', methods=['GET', 'POST'])
-def languagePreference():
-    if request.method == 'GET':
-        user = db_user()
+@app.route("/api/user_language", methods=["GET", "POST"])
+def language_preference():
+    """Get or update the authenticated user's UI language preference."""
 
-        user_language = "en"  # Default language
-        if user is not None:
-            user_language = user.user_language
+    if request.method == "GET":
+        user = _db_user()
+        user_language = user.user_language if user else "en"
 
-        return jsonify(
-            {
-                "success": True,
-                "data": {
-                    "user_language": user_language
-                },
-                "error": []
-            }), 200
+        return jsonify({
+            "success": True,
+            "data":   {"user_language": user_language},
+            "errors": [],
+        }), 200
 
-    elif request.method == 'POST':
+    elif request.method == "POST":
         data = request.get_json()
-        user_language = data.get('user_language')
+        if not data:
+            raise ValidationError("Request body must be JSON.")
+
+        user_language = data.get("user_language")
+        if not user_language:
+            raise ValidationError("Missing required field: 'user_language'.")
 
         cur_username = MW_OAUTH.get_current_user(True)
         user = User.query.filter_by(username=cur_username).first()
@@ -213,36 +287,45 @@ def languagePreference():
 
         try:
             db.session.commit()
-            return jsonify({ "success": True, "data": {}, "errors": []}), 200
-        except:
+            logger.info("UI language updated to '%s' for user '%s'", user_language, cur_username)
+            return jsonify({"success": True, "data": {}, "errors": []}), 200
+        except Exception as e:
             db.session.rollback()
-            return jsonify({ "success": False, "data": {}, "errors": ["Database Error"]}), 500
+            raise DatabaseError(
+                f"Failed to save language preference for '{cur_username}'."
+            ) from e
 
     else:
-        return jsonify({ "success": False, "data": {}, "errors": ["Invalid Request"]}), 400
+        raise ValidationError("Method not allowed.")
 
 
-@app.route('/api/get_wikitext', methods=['GET'])
+@app.route("/api/get_wikitext", methods=["GET"])
 def get_wikitext():
-    src_lang = request.args.get('src_lang')
-    src_project = request.args.get('src_project')
-    src_filename = request.args.get('src_filename')
-    tr_lang = request.args.get('tr_lang')
+    """
+    Fetch and optionally localise the wikitext for a source file.
 
-    # In any case, return the strings only with 200 status code
+    Returns ``{"wikitext": ""}`` on any failure – this endpoint is best-effort
+    and should not block the upload flow.
+    """
+    src_lang     = request.args.get("src_lang")
+    src_project  = request.args.get("src_project")
+    src_filename = request.args.get("src_filename")
+    tr_lang      = request.args.get("tr_lang")
+
     if not all([src_lang, src_project, src_filename, tr_lang]):
+        # Missing params – silently return empty string so the UI degrades gracefully.
         return jsonify({"wikitext": ""}), 200
 
     src_endpoint = f"https://{src_lang}.{src_project}.org/w/api.php"
     content_params = {
-        "action": "query",
-        "format": "json",
-        "prop": "revisions",
-        "titles": src_filename,
+        "action":        "query",
+        "format":        "json",
+        "prop":          "revisions",
+        "titles":        src_filename,
         "formatversion": "2",
-        "rvprop": "content",
-        "rvslots": "main",
-        "origin": "*"
+        "rvprop":        "content",
+        "rvslots":       "main",
+        "origin":        "*",
     }
 
     try:
@@ -254,115 +337,166 @@ def get_wikitext():
         if page_data and page_data[0].get("revisions"):
             wikitext = page_data[0]["revisions"][0]["slots"]["main"]["content"]
             wikitext = get_localized_wikitext(wikitext, src_endpoint, tr_lang)
-
             return jsonify({"wikitext": wikitext}), 200
-        else:
-            return jsonify({"wikitext": ""}), 200
-    except:
+
+        return jsonify({"wikitext": ""}), 200
+
+    except Exception as e:
+        # Log the real error for debugging but return a safe empty response so
+        # the upload flow is not blocked by a wikitext-fetch failure.
+        logger.warning(
+            "Failed to fetch wikitext for '%s' from %s.%s: %s",
+            src_filename, src_lang, src_project, e,
+        )
         return jsonify({"wikitext": ""}), 200
 
 
-@app.route('/api/edit_page', methods=['POST'])
-def editPage():
-    if request.method == 'POST':
-        data = request.get_json()
-        targetUrl = data.get('targetUrl')
-        content = data.get('content')
+@app.route("/api/edit_page", methods=["POST"])
+def edit_page():
+    """Append wikitext content to a file description page on a target wiki."""
 
-        match = re.findall(r"(\w+)\.(\w+)\.org/wiki/", targetUrl)
+    data = request.get_json()
+    if not data:
+        raise ValidationError("Request body must be JSON.")
 
-        target_project = match[0][1]
-        target_lang = match[0][0]
-        target_filename = targetUrl.split('/')[-1]
+    target_url = data.get("targetUrl")
+    content    = data.get("content")
 
-        target_endpoint = "https://" + target_lang + "." + target_project + ".org/w/api.php"
+    if not target_url or content is None:
+        raise ValidationError("Missing required fields: 'targetUrl' and 'content'.")
 
-        # Authenticate Session
-        ses = authenticated_session()
+    match = re.findall(r"(\w+)\.(\w+)\.org/wiki/", target_url)
+    if not match:
+        raise ValidationError(
+            "Could not parse target wiki from 'targetUrl'. "
+            "Expected format: https://<lang>.<project>.org/wiki/…"
+        )
 
-        # API Parameter to get CSRF Token
-        csrf_param = {
-            "action": "query",
-            "meta": "tokens",
-            "format": "json"
-        }
+    target_lang    = match[0][0]
+    target_project = match[0][1]
+    target_filename = target_url.split("/")[-1]
+    target_endpoint = f"https://{target_lang}.{target_project}.org/w/api.php"
 
-        response = requests.get(url=target_endpoint, params=csrf_param, auth=ses)
-        csrf_token = response.json()["query"]["tokens"]["csrftoken"]
+    ses = _authenticated_session()
+    if ses is None:
+        raise AuthenticationError()
 
-        # API Parameters to edit the page
-        edit_params = {
-            "action": "edit",
-            "title": "File:" + target_filename.split(':')[1],
-            "token": csrf_token,
-            "format": "json",
-            "appendtext": content
-        }
+    # Fetch a CSRF token from the target wiki.
+    try:
+        csrf_response = requests.get(
+            url=target_endpoint,
+            params={"action": "query", "meta": "tokens", "format": "json"},
+            auth=ses,
+        )
+        csrf_response.raise_for_status()
+        csrf_token = csrf_response.json()["query"]["tokens"]["csrftoken"]
+    except (KeyError, Exception) as e:
+        logger.error("Failed to obtain CSRF token from '%s': %s", target_endpoint, e)
+        raise ExternalAPIError("Could not obtain CSRF token from target wiki.")
 
-        response = requests.post(url=target_endpoint, data=edit_params, auth=ses)
+    # Submit the edit.
+    edit_params = {
+        "action":     "edit",
+        "title":      "File:" + target_filename.split(":")[-1],
+        "token":      csrf_token,
+        "format":     "json",
+        "appendtext": content,
+    }
 
-        if response.status_code == 200:
-            return jsonify({ "success": True, "data": {}, "errors": []}), 200
-        else:
-            return jsonify({ "success": False, "data": {}, "errors": ["Edit Error"]}), 500
+    try:
+        edit_response = requests.post(
+            url=target_endpoint, data=edit_params, auth=ses
+        )
+        edit_response.raise_for_status()
+    except Exception as e:
+        logger.error("Page edit request failed for '%s': %s", target_filename, e)
+        raise ExternalAPIError("Edit request to target wiki failed.")
 
-    else:
-        return jsonify({ "success": False, "data": {}, "errors": ["Invalid Request"]}), 400
+    logger.info("Successfully edited page '%s' on %s", target_filename, target_endpoint)
+    return jsonify({"success": True, "data": {}, "errors": []}), 200
 
 
-@app.route('/api/user', methods=['GET'])
+@app.route("/api/user", methods=["GET"])
 def get_base_variables():
+    """Return whether the current user is logged in and their username."""
     return jsonify({
-        "logged": logged() is not None,
-        "username": MW_OAUTH.get_current_user(True)
+        "logged":   _logged() is not None,
+        "username": MW_OAUTH.get_current_user(True),
     }), 200
 
-@app.route('/api/task_status/<task_id>', methods=['GET'])
-def get_task_status(task_id):
+
+@app.route("/api/task_status/<task_id>", methods=["GET"])
+def get_task_status(task_id: str):
     """
-    Endpoint to get the status and result of a Celery task.
+    Poll the status and result of an async Celery upload task.
+
+    Returns one of the Celery task states (PENDING, PROGRESS, SUCCESS, FAILURE)
+    along with the result payload on success or an error description on failure.
     """
     task = AsyncResult(task_id, app=celery_app)
-    response = {
-        "task_id": task_id,
-        "status": task.status,
-        "result": task.result if task.successful() else None,
-    }
-    
-    # If task failed, include error information
+    status = task.status  # PENDING | PROGRESS | SUCCESS | FAILURE
+
+    # Determine what to put in "data" based on the task state:
+    #   SUCCESS  → the dict returned by upload_image_task (wikipage_url, file_link)
+    #   PROGRESS → progress meta dict e.g. {"current": 25, "total": 100}
+    #   PENDING / FAILURE / other → None
+    if status == "SUCCESS":
+        data = task.result
+    elif status == "PROGRESS":
+        data = task.info  # task.info holds the meta passed to update_state()
+    else:
+        data = None
+
+    errors = []
     if task.failed():
-        response["error"] = str(task.result)
+        # task.result holds the exception instance; convert to string for JSON.
+        logger.error("Async task %s failed: %s", task_id, task.result)
+        errors = [str(task.result)]
 
-    return jsonify(response), 200
-
-
-def authenticated_session():
-    if 'mwoauth_access_token' in session:
-        auth = requests_oauthlib.OAuth1(
-            client_key=CONSUMER_KEY,
-            client_secret=CONSUMER_SECRET,
-            resource_owner_key=session['mwoauth_access_token']['key'],
-            resource_owner_secret=session['mwoauth_access_token']['secret']
-        )
-        return auth
-
-    return None
+    return jsonify({
+        "task_id": task_id,
+        "status":  status,
+        "data":    data,
+        "errors":  errors,
+    }), 200
 
 
-def db_user():
-    if logged():
-        user = User.query.filter_by(username=MW_OAUTH.get_current_user(True)).first()
-        return user
-    else:
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+def _authenticated_session():
+    """
+    Build an OAuth1 session from the stored access token.
+
+    Returns ``None`` if the user is not logged in (no token in session).
+    """
+    if "mwoauth_access_token" not in session:
         return None
 
+    return requests_oauthlib.OAuth1(
+        client_key=CONSUMER_KEY,
+        client_secret=CONSUMER_SECRET,
+        resource_owner_key=session["mwoauth_access_token"]["key"],
+        resource_owner_secret=session["mwoauth_access_token"]["secret"],
+    )
 
-def logged():
-    if MW_OAUTH.get_current_user(True) is not None:
-        return MW_OAUTH.get_current_user(True)
-    else:
+
+def _db_user():
+    """Return the ``User`` model instance for the current user, or ``None``."""
+    if not _logged():
         return None
+    return User.query.filter_by(username=MW_OAUTH.get_current_user(True)).first()
 
+
+def _logged():
+    """Return the current username if logged in, otherwise ``None``."""
+    return MW_OAUTH.get_current_user(True)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
     app.run()

--- a/error_handlers.py
+++ b/error_handlers.py
@@ -1,0 +1,54 @@
+
+
+import logging
+
+from flask import jsonify, request
+from werkzeug.exceptions import HTTPException
+
+logger = logging.getLogger(__name__)
+
+
+def register_error_handlers(app) -> None:
+    """Attach all error handlers to *app*."""
+
+    @app.errorhandler(HTTPException)
+    def handle_http_exception(e: HTTPException):
+        """Handles expected HTTP errors (our APIError subclasses and Flask's own).
+        Logged at WARNING – these are client-side mistakes, not server bugs."""
+        logger.warning(
+            "HTTP %s on %s %s – %s",
+            e.code,
+            request.method,
+            request.path,
+            e.description,
+        )
+        return (
+            jsonify({
+                "success": False,
+                "data":    {},
+                "errors":  [e.description],
+            }),
+            e.code,
+        )
+
+    @app.errorhandler(Exception)
+    def handle_generic_exception(e: Exception):
+        """Catch-all for unexpected exceptions. Full traceback is written to
+        the log; client only receives a safe generic message."""
+        logger.exception(
+            "Unhandled %s on %s %s",
+            type(e).__name__,
+            request.method,
+            request.path,
+        )
+        return (
+            jsonify({
+                "success": False,
+                "data":    {},
+                "errors":  [
+                    "An unexpected internal error occurred. "
+                    "Please try again or contact support."
+                ],
+            }),
+            500,
+        )

--- a/exceptions.py
+++ b/exceptions.py
@@ -1,0 +1,121 @@
+from werkzeug.exceptions import HTTPException
+
+class WikifileTransferError(Exception):
+    """
+    Root exception for every error raised within Wikifile-Transfer.
+
+    Catching this class catches *all* application-level errors, which is
+    useful in Celery task wrappers and integration tests.
+    """
+
+
+# ---------------------------------------------------------------------------
+# HTTP / API exceptions  (also subclass HTTPException for Flask routing)
+# ---------------------------------------------------------------------------
+
+class APIError(WikifileTransferError, HTTPException):
+    """
+    Base class for errors that must be returned as an HTTP response.
+
+    Inherits from both ``WikifileTransferError`` (application family) and
+    ``werkzeug.exceptions.HTTPException`` (Flask error-handler dispatch).
+
+    Parameters
+    ----------
+    message : str
+        Human-readable description included in the JSON error envelope.
+    status_code : int
+        HTTP status code to return to the client (default: 400).
+    """
+
+    def __init__(self, message: str, status_code: int = 400) -> None:
+        # Initialise both parent classes explicitly to avoid MRO surprises.
+        WikifileTransferError.__init__(self, message)
+        self.code = status_code
+        self.description = message
+
+    def __str__(self) -> str:
+        # Override HTTPException.__str__ which would prepend "NNN StatusText: ".
+        # Returning just the description keeps str(err) == err.description,
+        # which is the natural expectation for an application exception.
+        return self.description
+
+
+class ValidationError(APIError):
+    """
+    Raised when incoming request data fails validation.
+
+    HTTP 422 Unprocessable Entity – the server understands the content type
+    but the data itself is semantically invalid (e.g. missing required field,
+    malformed URL).
+    """
+
+    def __init__(self, message: str = "Invalid or missing request data") -> None:
+        super().__init__(message, status_code=422)
+
+
+class NotFoundError(APIError):
+
+    def __init__(self, message: str = "The requested resource was not found") -> None:
+        super().__init__(message, status_code=404)
+
+
+class AuthenticationError(APIError):
+
+    def __init__(self, message: str = "Authentication required. Please log in.") -> None:
+        super().__init__(message, status_code=401)
+
+
+class UploadError(APIError):
+    """
+    Raised when a file upload to the target wiki is rejected or fails.
+
+    HTTP 502 Bad Gateway – the upstream wiki returned an error or an
+    unexpected response structure.
+    """
+
+    def __init__(self, message: str = "File upload to target wiki failed") -> None:
+        super().__init__(message, status_code=502)
+
+
+class ExternalAPIError(APIError):
+    """
+    Raised when a call to an external MediaWiki REST/Action API fails.
+
+    HTTP 502 Bad Gateway – covers network errors, non-200 responses, and
+    unexpected JSON shapes from upstream wikis.
+    """
+
+    def __init__(self, message: str = "External MediaWiki API request failed") -> None:
+        super().__init__(message, status_code=502)
+
+
+# ---------------------------------------------------------------------------
+# Internal (non-HTTP) exceptions
+# ---------------------------------------------------------------------------
+
+class DownloadError(WikifileTransferError):
+    """
+    Raised when downloading a source file from a wiki fails.
+
+    This is an *internal* error; callers are expected to catch it and either
+    re-raise as an ``APIError`` subclass or log and return a safe response.
+    """
+
+
+class DatabaseError(WikifileTransferError):
+    """
+    Raised when a SQLAlchemy / database operation fails.
+
+    Callers should roll back the session before raising this exception and
+    avoid leaking raw SQLAlchemy messages to clients.
+    """
+
+
+class TaskError(WikifileTransferError):
+    """
+    Raised inside a Celery task when an unrecoverable error is encountered.
+
+    The Celery task infrastructure catches this, logs the full traceback, and
+    marks the task as FAILURE so the polling endpoint can report it correctly.
+    """

--- a/logging_config.py
+++ b/logging_config.py
@@ -1,0 +1,59 @@
+"""
+logging_config.py – Structured, rotating file-based logging for Wikifile-Transfer.
+
+Call ``configure_logging(app)`` once after the Flask app is configured.
+Log files are written to the ``logs/`` directory at the project root.
+
+Format:  2024-01-15 12:34:56 [INFO    ] app: Server started
+         2024-01-15 12:34:57 [WARNING ] error_handlers: HTTP 422 on POST /api/upload
+"""
+
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+
+from flask import Flask
+
+
+def configure_logging(flask_app: Flask) -> None:
+    """
+    Attach a rotating file handler and a console handler to the root logger.
+
+    Settings:
+      - Log directory : logs/  (created automatically if missing)
+      - File size cap : 5 MB per file, 3 backups kept
+      - Log level     : DEBUG in dev (flask_app.config["DEBUG"]=True), INFO otherwise
+    """
+    log_dir = os.path.join(os.path.dirname(__file__), "logs")
+    os.makedirs(log_dir, exist_ok=True)
+
+    log_level = logging.DEBUG if flask_app.config.get("DEBUG") else logging.INFO
+
+    formatter = logging.Formatter(
+        fmt="%(asctime)s [%(levelname)-8s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    # Rotating file handler – rotate at 5 MB, keep 3 backup files.
+    file_handler = RotatingFileHandler(
+        filename=os.path.join(log_dir, "app.log"),
+        maxBytes=5 * 1024 * 1024,
+        backupCount=3,
+        encoding="utf-8",
+    )
+    file_handler.setFormatter(formatter)
+    file_handler.setLevel(log_level)
+
+    # Console handler so logs are visible in Docker / dev terminal output.
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(formatter)
+    console_handler.setLevel(log_level)
+
+    # Apply to the root logger so every module inherits the same config.
+    root_logger = logging.getLogger()
+    root_logger.setLevel(log_level)
+
+    # Guard against duplicate handlers when called more than once (e.g. tests).
+    if not root_logger.handlers:
+        root_logger.addHandler(file_handler)
+        root_logger.addHandler(console_handler)

--- a/tasks.py
+++ b/tasks.py
@@ -1,58 +1,119 @@
-from celeryWorker import app
+"""
+tasks.py – Celery task definitions for Wikifile-Transfer.
+
+Async tasks handle large file uploads (> 50 MB) that would time out if
+processed synchronously. The client receives a task_id immediately and
+polls /api/task_status/<task_id> for updates.
+
+Every failure raises TaskError so Celery marks the task as FAILURE and
+the status endpoint can report a clean error message to the client.
+"""
+
+import logging
+
 import requests
 import requests_oauthlib
-import os
+
+from celeryWorker import app
+from exceptions import TaskError
+
+logger = logging.getLogger(__name__)
+
 
 @app.task(bind=True)
-def upload_image_task(self, file_path, tr_filename, src_fileext, tr_endpoint, OAuthObj):
-    ses = requests_oauthlib.OAuth1(
-        client_key=OAuthObj["consumer_key"],
-        client_secret= OAuthObj["consumer_secret"],
-        resource_owner_key=OAuthObj["key"],
-        resource_owner_secret=OAuthObj["secret"]
+def upload_image_task(self, file_path, tr_filename, src_fileext, tr_endpoint, oauth_obj):
+    """
+    Upload *file_path* to *tr_endpoint* as an authenticated Celery task.
+
+    Progress states: PROGRESS at 0%, 25%, 75%, 100% → then SUCCESS or FAILURE.
+
+    Raises
+    ------
+    TaskError
+        Wraps any failure so Celery marks the task FAILURE and the original
+        message is available through the /api/task_status endpoint.
+    """
+    task_id = self.request.id
+    logger.info(
+        "Task %s started: uploading '%s.%s' to %s",
+        task_id, tr_filename, src_fileext, tr_endpoint,
     )
-    self.update_state(state='PROGRESS', meta={'current': 0, 'total': 100})
-    
-    # API Parameter to get CSRF Token
-    csrf_param = {
-        "action": "query",
-        "meta": "tokens",
-        "format": "json"
-    }
 
-    response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses)
-    csrf_token = response.json()["query"]["tokens"]["csrftoken"]
+    ses = requests_oauthlib.OAuth1(
+        client_key=oauth_obj["consumer_key"],
+        client_secret=oauth_obj["consumer_secret"],
+        resource_owner_key=oauth_obj["key"],
+        resource_owner_secret=oauth_obj["secret"],
+    )
 
-    self.update_state(state='PROGRESS', meta={'current': 25, 'total': 100})
+    self.update_state(state="PROGRESS", meta={"current": 0, "total": 100})
 
-    # API Parameter to upload the file
-    upload_param = {
-        "action": "upload",
-        "filename": tr_filename + "." + src_fileext,
-        "format": "json",
-        "token": csrf_token,
-        "ignorewarnings": 1
-    }
-
-    # Read the file for POST request
-    file = {
-        'file': open(file_path, 'rb')
-    }
-
-    response = requests.post(url=tr_endpoint, files=file, data=upload_param, auth=ses).json()
-
-    self.update_state(state='PROGRESS', meta={'current': 75, 'total': 100})
-
-    # Try block to get Link and URL
+    # --- Step 1: Fetch CSRF token (0% → 25%) --------------------------------
     try:
-        wikifile_url = response["upload"]["imageinfo"]["descriptionurl"]
-        file_link = response["upload"]["imageinfo"]["url"]
-    except KeyError:
-        return {"success": False, "data": {}, "errors": ["Upload failed"]}
+        csrf_response = requests.get(
+            url=tr_endpoint,
+            params={"action": "query", "meta": "tokens", "format": "json"},
+            auth=ses,
+        )
+        csrf_response.raise_for_status()
+        csrf_token = csrf_response.json()["query"]["tokens"]["csrftoken"]
+    except requests.RequestException as e:
+        logger.exception("Task %s – network error fetching CSRF token", task_id)
+        raise TaskError(f"Failed to fetch CSRF token: {e}") from e
+    except (KeyError, ValueError) as e:
+        logger.exception("Task %s – unexpected CSRF token response", task_id)
+        raise TaskError(f"Unexpected CSRF token response: {e}") from e
 
-    self.update_state(state='PROGRESS', meta={'current': 100, 'total': 100})
+    self.update_state(state="PROGRESS", meta={"current": 25, "total": 100})
 
-    return {
-        "wikipage_url": wikifile_url,
-        "file_link": file_link
+    # --- Step 2: Upload file (25% → 75%) ------------------------------------
+    upload_param = {
+        "action":         "upload",
+        "filename":       f"{tr_filename}.{src_fileext}",
+        "format":         "json",
+        "token":          csrf_token,
+        "ignorewarnings": 1,
     }
+
+    # Use a context manager so the file handle is always closed after the
+    # request, even if an exception is raised mid-upload.
+    try:
+        with open(file_path, "rb") as fh:
+            upload_response = requests.post(
+                url=tr_endpoint,
+                files={"file": fh},
+                data=upload_param,
+                auth=ses,
+            )
+        upload_response.raise_for_status()
+        response_json = upload_response.json()
+    except OSError as e:
+        logger.exception("Task %s – could not open '%s'", task_id, file_path)
+        raise TaskError(f"Could not read local file for upload: {e}") from e
+    except requests.RequestException as e:
+        logger.exception("Task %s – network error during upload", task_id)
+        raise TaskError(f"Upload request failed: {e}") from e
+    except ValueError as e:
+        logger.exception("Task %s – invalid JSON in upload response", task_id)
+        raise TaskError(f"Unexpected upload response format: {e}") from e
+
+    self.update_state(state="PROGRESS", meta={"current": 75, "total": 100})
+
+    # --- Step 3: Parse response (75% → 100%) --------------------------------
+    try:
+        wikifile_url = response_json["upload"]["imageinfo"]["descriptionurl"]
+        file_link    = response_json["upload"]["imageinfo"]["url"]
+    except KeyError:
+        # The wiki rejected the upload (permissions, duplicate, etc.).
+        logger.error(
+            "Task %s – imageinfo missing in upload response: %s",
+            task_id, response_json,
+        )
+        raise TaskError(
+            f"Upload rejected by target wiki. Response: {response_json}"
+        )
+
+    self.update_state(state="PROGRESS", meta={"current": 100, "total": 100})
+    logger.info("Task %s completed: %s", task_id, wikifile_url)
+
+    return {"wikipage_url": wikifile_url, "file_link": file_link}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,100 @@
+"""
+tests/conftest.py – Pytest configuration and shared fixtures.
+
+The Flask application is imported once per test session with external
+dependencies replaced by mocks so no live infrastructure is required:
+
+  - celery.Celery  →  MagicMock  (no Redis broker needed)
+  - flask_mwoauth.MWOAuth → MagicMock  (no OAuth server needed)
+
+Individual tests can override specific mock behaviour via monkeypatching.
+The test database is always an in-memory SQLite instance so MySQL is not
+required either.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap: apply patches BEFORE the application module is imported.
+#
+# celeryWorker.py executes  app = Celery(...)  at import time, which would
+# try to reach a Redis broker.  flask_mwoauth.MWOAuth contacts an OAuth
+# server on construction.  Both are mocked out here so the test suite runs
+# with zero external infrastructure.
+# ---------------------------------------------------------------------------
+
+# Build a realistic-enough MWOAuth mock so Flask doesn't reject the blueprint.
+_mock_mwoauth_instance = MagicMock()
+_mock_mwoauth_instance.bp.name = "mwoauth"       # Flask requires a unique blueprint name
+_mock_mwoauth_instance.get_current_user.return_value = None  # unauthenticated by default
+
+_celery_patcher = patch("celery.Celery", MagicMock())
+_mwoauth_patcher = patch("flask_mwoauth.MWOAuth", return_value=_mock_mwoauth_instance)
+
+_celery_patcher.start()
+_mwoauth_patcher.start()
+
+import app as _app_module  # noqa: E402 – must come after patches
+from model import db as _db  # noqa: E402
+
+_celery_patcher.stop()
+_mwoauth_patcher.stop()
+
+
+# ---------------------------------------------------------------------------
+# Session-scoped fixtures (created once for the entire test run)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session")
+def flask_app():
+    """
+    Application configured for testing:
+    - In-memory SQLite (no MySQL needed).
+    - TESTING=True so Flask propagates exceptions to the test client instead
+      of returning a generic 500, which makes assertion errors easier to read.
+    """
+    _app_module.app.config.update({
+        "TESTING": True,
+        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+    })
+    with _app_module.app.app_context():
+        _db.create_all()
+    return _app_module.app
+
+
+@pytest.fixture(scope="session")
+def client(flask_app):
+    """Unauthenticated test client – no OAuth session cookie present."""
+    return flask_app.test_client()
+
+
+# ---------------------------------------------------------------------------
+# Function-scoped fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def auth_client(flask_app):
+    """
+    Test client with a fake OAuth session injected.
+
+    Use this fixture for routes that require the user to be logged in
+    (upload, edit_page, preference POST, language POST).
+    """
+    with flask_app.test_client() as c:
+        with c.session_transaction() as sess:
+            sess["mwoauth_access_token"] = {
+                "key":    "test_oauth_key",
+                "secret": "test_oauth_secret",
+            }
+        yield c
+
+
+@pytest.fixture
+def mock_mwoauth():
+    """
+    Expose the MWOAuth mock instance so individual tests can set return
+    values (e.g. ``mock_mwoauth.get_current_user.return_value = 'Alice'``).
+    """
+    return _mock_mwoauth_instance

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,167 @@
+"""
+tests/test_exceptions.py – Unit tests for the custom exception hierarchy.
+
+Covers:
+  1. Inheritance chain  – every exception descends from WikifileTransferError.
+  2. HTTP status codes  – APIError subclasses carry the right `.code`.
+  3. werkzeug compat    – APIError subclasses are catchable as HTTPException.
+  4. Message handling   – default and custom descriptions are preserved.
+"""
+
+import pytest
+from werkzeug.exceptions import HTTPException
+
+from exceptions import (
+    APIError,
+    AuthenticationError,
+    DatabaseError,
+    DownloadError,
+    ExternalAPIError,
+    NotFoundError,
+    TaskError,
+    UploadError,
+    ValidationError,
+    WikifileTransferError,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Inheritance chain
+# ---------------------------------------------------------------------------
+
+class TestInheritanceChain:
+    """Every exception must ultimately descend from WikifileTransferError."""
+
+    def test_api_error(self):
+        assert issubclass(APIError, WikifileTransferError)
+
+    def test_validation_error(self):
+        assert issubclass(ValidationError, WikifileTransferError)
+
+    def test_not_found_error(self):
+        assert issubclass(NotFoundError, WikifileTransferError)
+
+    def test_authentication_error(self):
+        assert issubclass(AuthenticationError, WikifileTransferError)
+
+    def test_upload_error(self):
+        assert issubclass(UploadError, WikifileTransferError)
+
+    def test_external_api_error(self):
+        assert issubclass(ExternalAPIError, WikifileTransferError)
+
+    def test_download_error(self):
+        assert issubclass(DownloadError, WikifileTransferError)
+
+    def test_database_error(self):
+        assert issubclass(DatabaseError, WikifileTransferError)
+
+    def test_task_error(self):
+        assert issubclass(TaskError, WikifileTransferError)
+
+    def test_api_subclasses_are_also_api_error(self):
+        """ValidationError, NotFoundError, etc. must all be APIError."""
+        for cls in (ValidationError, NotFoundError, AuthenticationError,
+                    UploadError, ExternalAPIError):
+            assert issubclass(cls, APIError), f"{cls.__name__} is not an APIError"
+
+
+# ---------------------------------------------------------------------------
+# 2. HTTP status codes
+# ---------------------------------------------------------------------------
+
+class TestHTTPStatusCodes:
+    """APIError subclasses must expose the correct HTTP status via .code."""
+
+    def test_api_error_default_400(self):
+        assert APIError("oops").code == 400
+
+    def test_api_error_custom_status(self):
+        err = APIError("service unavailable", status_code=503)
+        assert err.code == 503
+
+    def test_validation_error_is_422(self):
+        assert ValidationError().code == 422
+
+    def test_not_found_error_is_404(self):
+        assert NotFoundError().code == 404
+
+    def test_authentication_error_is_401(self):
+        assert AuthenticationError().code == 401
+
+    def test_upload_error_is_502(self):
+        assert UploadError().code == 502
+
+    def test_external_api_error_is_502(self):
+        assert ExternalAPIError().code == 502
+
+
+# ---------------------------------------------------------------------------
+# 3. werkzeug / Flask compatibility
+# ---------------------------------------------------------------------------
+
+class TestFlaskHTTPExceptionIntegration:
+    """APIError subclasses must be catchable as werkzeug HTTPExceptions so
+    Flask routes them to the correct error handler automatically."""
+
+    def test_api_error_isinstance_http_exception(self):
+        assert isinstance(APIError("msg"), HTTPException)
+
+    def test_validation_error_isinstance_http_exception(self):
+        assert isinstance(ValidationError(), HTTPException)
+
+    @pytest.mark.parametrize("exc_cls", [
+        ValidationError, NotFoundError, AuthenticationError,
+        UploadError, ExternalAPIError,
+    ])
+    def test_can_catch_as_http_exception(self, exc_cls):
+        with pytest.raises(HTTPException) as exc_info:
+            raise exc_cls()
+        assert exc_info.value.code == exc_cls().code
+
+    def test_can_catch_all_as_wikifiletransfer_error(self):
+        """Catching WikifileTransferError must intercept every app exception."""
+        for exc_cls in (ValidationError, AuthenticationError, DownloadError,
+                        DatabaseError, TaskError):
+            with pytest.raises(WikifileTransferError):
+                raise exc_cls()
+
+
+# ---------------------------------------------------------------------------
+# 4. Message handling
+# ---------------------------------------------------------------------------
+
+class TestMessageHandling:
+    """Default and custom descriptions must be preserved correctly."""
+
+    def test_api_error_stores_message_as_description(self):
+        err = APIError("something went wrong")
+        assert err.description == "something went wrong"
+
+    def test_api_error_also_stores_as_str(self):
+        err = APIError("fail")
+        assert str(err) == "fail"
+
+    def test_validation_error_custom_message(self):
+        err = ValidationError("'srcUrl' is required")
+        assert err.description == "'srcUrl' is required"
+
+    def test_validation_error_default_message_is_informative(self):
+        err = ValidationError()
+        assert len(err.description) > 5  # Not blank
+
+    def test_authentication_error_default_message_present(self):
+        err = AuthenticationError()
+        assert err.description  # truthy / non-empty
+
+    def test_not_found_error_default_contains_not_found(self):
+        err = NotFoundError()
+        assert "not found" in err.description.lower()
+
+    def test_task_error_preserves_message(self):
+        err = TaskError("Redis connection refused")
+        assert str(err) == "Redis connection refused"
+
+    def test_download_error_preserves_message(self):
+        err = DownloadError("HTTP 403 from upstream")
+        assert str(err) == "HTTP 403 from upstream"

--- a/utils.py
+++ b/utils.py
@@ -1,114 +1,268 @@
+"""
+utils.py – Shared utility functions for Wikifile-Transfer.
+
+Functions
+---------
+download_image      Download a source file from a MediaWiki wiki.
+process_upload      Upload a local file to a target MediaWiki wiki.
+get_localized_wikitext  Localise an Article= template parameter in wikitext.
+getHeader           Return the standard User-Agent header dict.
+"""
+
 import datetime
-import requests
+import logging
+
 import mwparserfromhell
+import requests
+
 from templatelist import TEMPLATES
+from exceptions import DownloadError, UploadError
 
-def download_image(src_project, src_lang, src_filename):
-    src_endpoint = "https://"+ src_lang + "." + src_project + ".org/w/api.php"
+logger = logging.getLogger(__name__)
 
+
+# ---------------------------------------------------------------------------
+# Image downloading
+# ---------------------------------------------------------------------------
+
+def download_image(src_project: str, src_lang: str, src_filename: str) -> str:
+    """
+    Download *src_filename* from *src_lang*.*src_project*.org and save it to
+    the ``temp_images/`` directory.
+
+    Returns the generated local filename on success.
+
+    Raises
+    ------
+    DownloadError
+        If the image URL cannot be resolved, the download fails, or the file
+        cannot be written to disk.
+    """
+    src_endpoint = f"https://{src_lang}.{src_project}.org/w/api.php"
     param = {
-        "action": "query",
-        "format": "json",
-        "prop": "imageinfo",
-        "titles": src_filename,
-        "iiprop": "url",
-        "iilocalonly": 1
+        "action":      "query",
+        "format":      "json",
+        "prop":        "imageinfo",
+        "titles":      src_filename,
+        "iiprop":      "url",
+        "iilocalonly": 1,
     }
 
-    page = requests.get(url=src_endpoint, params=param).json()['query']['pages']
+    # --- Resolve direct URL via the MediaWiki API ---------------------------
+    try:
+        api_response = requests.get(url=src_endpoint, params=param)
+        api_response.raise_for_status()
+        pages = api_response.json()["query"]["pages"]
+    except requests.RequestException as e:
+        raise DownloadError(
+            f"Network error querying image info for '{src_filename}' "
+            f"on {src_lang}.{src_project}: {e}"
+        ) from e
+    except (KeyError, ValueError) as e:
+        raise DownloadError(
+            f"Unexpected API response for '{src_filename}' "
+            f"on {src_lang}.{src_project}: {e}"
+        ) from e
 
     try:
-        image_url = list (page.values()) [0]["imageinfo"][0]["url"]
-    except KeyError:
-        return None
+        image_url = list(pages.values())[0]["imageinfo"][0]["url"]
+    except (KeyError, IndexError):
+        # Image not found on the source wiki (e.g. it is only on Commons).
+        raise DownloadError(
+            f"'{src_filename}' was not found on {src_lang}.{src_project}.org. "
+            "It may be hosted on Wikimedia Commons instead."
+        )
 
-    # Create a unique file name based on time
-    current_time = str(datetime.datetime.now())
-    get_filename = current_time.replace(':', '_')
-    get_filename = get_filename.replace(' ', '_')
+    # --- Download the binary file -------------------------------------------
+    try:
+        download_response = requests.get(image_url, allow_redirects=True)
+        download_response.raise_for_status()
+    except requests.RequestException as e:
+        raise DownloadError(
+            f"Failed to download image from '{image_url}': {e}"
+        ) from e
 
-    # Download the Image File
-    r = requests.get(image_url, allow_redirects=True)
-    filename = get_filename + "." + r.headers.get('content-type').replace('image/', '')
-    open("temp_images/" + filename, 'wb').write(r.content)
+    # Build a collision-resistant filename from the current timestamp.
+    timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H_%M_%S_%f")
+    content_type = download_response.headers.get("content-type", "image/jpeg")
+    extension = content_type.replace("image/", "")
+    local_filename = f"{timestamp}.{extension}"
 
-    return filename
+    # Write to disk using a context manager so the handle is always closed.
+    try:
+        with open(f"temp_images/{local_filename}", "wb") as fh:
+            fh.write(download_response.content)
+    except OSError as e:
+        raise DownloadError(
+            f"Failed to save downloaded file '{local_filename}' to disk: {e}"
+        ) from e
+
+    logger.info("Downloaded '%s' → temp_images/%s", src_filename, local_filename)
+    return local_filename
 
 
-def process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses):
-    # API Parameter to get CSRF Token
-    csrf_param = {
-        "action": "query",
-        "meta": "tokens",
-        "format": "json"
-    }
+# ---------------------------------------------------------------------------
+# File upload to target wiki
+# ---------------------------------------------------------------------------
 
-    response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses)
-    csrf_token = response.json()["query"]["tokens"]["csrftoken"]
+def process_upload(
+    file_path: str,
+    tr_filename: str,
+    src_fileext: str,
+    tr_endpoint: str,
+    ses,
+):
+    """
+    Upload the file at *file_path* to *tr_endpoint* using the authenticated
+    session *ses*.
 
-    # API Parameter to upload the file
+    Returns a dict ``{"wikipage_url": …, "file_link": …}`` on success.
+
+    Raises
+    ------
+    UploadError
+        If the CSRF token cannot be obtained, the POST request fails, the
+        local file cannot be read, or the wiki rejects the upload.
+    """
+    # --- Obtain a CSRF token ------------------------------------------------
+    csrf_param = {"action": "query", "meta": "tokens", "format": "json"}
+
+    try:
+        csrf_response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses)
+        csrf_response.raise_for_status()
+        csrf_token = csrf_response.json()["query"]["tokens"]["csrftoken"]
+    except requests.RequestException as e:
+        raise UploadError(
+            f"Network error fetching CSRF token from '{tr_endpoint}': {e}"
+        ) from e
+    except (KeyError, ValueError) as e:
+        raise UploadError(
+            f"Unexpected CSRF token response from '{tr_endpoint}': {e}"
+        ) from e
+
     upload_param = {
-        "action": "upload",
-        "filename": tr_filename + "." + src_fileext,
-        "format": "json",
-        "token": csrf_token,
-        "ignorewarnings": 1
+        "action":         "upload",
+        "filename":       f"{tr_filename}.{src_fileext}",
+        "format":         "json",
+        "token":          csrf_token,
+        "ignorewarnings": 1,
     }
 
-    # Read the file for POST request
-    file = {
-        'file': open(file_path, 'rb')
-    }
-
-    response = requests.post(url=tr_endpoint, files=file, data=upload_param, auth=ses).json()
-
-    # Try block to get Link and URL
+    # --- POST the file ------------------------------------------------------
+    # The file handle is opened inside a context manager so it is guaranteed
+    # to be closed after the request completes, even if an exception is raised.
     try:
-        wikifile_url = response["upload"]["imageinfo"]["descriptionurl"]
-        file_link = response["upload"]["imageinfo"]["url"]
+        with open(file_path, "rb") as fh:
+            upload_response = requests.post(
+                url=tr_endpoint,
+                files={"file": fh},
+                data=upload_param,
+                auth=ses,
+            )
+        upload_response.raise_for_status()
+        response_json = upload_response.json()
+    except OSError as e:
+        raise UploadError(
+            f"Could not open local file '{file_path}' for upload: {e}"
+        ) from e
+    except requests.RequestException as e:
+        raise UploadError(
+            f"Network error uploading '{tr_filename}' to '{tr_endpoint}': {e}"
+        ) from e
+    except ValueError as e:
+        raise UploadError(
+            f"Invalid JSON in upload response from '{tr_endpoint}': {e}"
+        ) from e
+
+    # --- Parse the upload response ------------------------------------------
+    try:
+        wikifile_url = response_json["upload"]["imageinfo"]["descriptionurl"]
+        file_link    = response_json["upload"]["imageinfo"]["url"]
     except KeyError:
-        return None
+        # The wiki returned a response but without imageinfo – upload rejected
+        # (e.g. insufficient permissions, duplicate file, etc.).
+        raise UploadError(
+            f"Upload of '{tr_filename}' was rejected by the target wiki. "
+            f"Response: {response_json}"
+        )
 
-    return {
-        "wikipage_url": wikifile_url,
-        "file_link": file_link
-    }
+    logger.info("Uploaded '%s' → %s", tr_filename, wikifile_url)
+    return {"wikipage_url": wikifile_url, "file_link": file_link}
 
 
-def get_localized_wikitext(wikitext, src_endpoint, target_lang):
+# ---------------------------------------------------------------------------
+# Wikitext localisation
+# ---------------------------------------------------------------------------
+
+def get_localized_wikitext(wikitext: str, src_endpoint: str, target_lang: str) -> str:
+    """
+    Replace the ``Article=`` parameter in known infobox templates with the
+    localised article title for *target_lang*.
+
+    Falls back to the original *wikitext* if the API call fails or the
+    template/language is not found, so the upload flow is never blocked.
+    """
     wikicode = mwparserfromhell.parse(wikitext)
 
     for template in wikicode.filter_templates():
-        if template.name.strip() in TEMPLATES:
-            if template.has("Article"):
-                article_value = template.get("Article")
+        if template.name.strip() not in TEMPLATES:
+            continue
 
-                if article_value:
-                    article_title = article_value.value.strip()
-                    lang_param = {
-                        "action": "query",
-                        "format": "json",
-                        "prop": "langlinks",
-                        "titles": article_title,
-                        "formatversion": "2"
-                    }
+        if not template.has("Article"):
+            continue
 
-                    try:
-                        response = requests.get(url=src_endpoint, params=lang_param)
-                        response.raise_for_status()
-                        langlinks = response.json()["query"]["pages"][0]["langlinks"]
+        article_value = template.get("Article")
+        if not article_value:
+            continue
 
-                        for langlink in langlinks:
-                            if langlink["lang"] == target_lang:
-                                template.add("Article", langlink["title"])
-                                break
-                    except:
-                        return str(wikicode)
+        article_title = article_value.value.strip()
+        lang_params = {
+            "action":        "query",
+            "format":        "json",
+            "prop":          "langlinks",
+            "titles":        article_title,
+            "formatversion": "2",
+        }
+
+        try:
+            response = requests.get(url=src_endpoint, params=lang_params)
+            response.raise_for_status()
+            langlinks = response.json()["query"]["pages"][0]["langlinks"]
+
+            for langlink in langlinks:
+                if langlink["lang"] == target_lang:
+                    template.add("Article", langlink["title"])
+                    logger.debug(
+                        "Localised Article '%s' → '%s' (%s)",
+                        article_title, langlink["title"], target_lang,
+                    )
+                    break
+
+        except (KeyError, IndexError):
+            # No langlinks found for this article – keep the original value.
+            logger.debug(
+                "No '%s' langlink found for article '%s'", target_lang, article_title
+            )
+        except requests.RequestException as e:
+            # Network failure – log and return what we have so far rather than
+            # failing the entire upload.
+            logger.warning(
+                "Failed to fetch langlinks for '%s' from '%s': %s",
+                article_title, src_endpoint, e,
+            )
+            return str(wikicode)
 
     return str(wikicode)
 
-def getHeader():
-    agent = 'Wikifile-transfer/1.0 (https://wikifile-transfer.toolforge.org; 0freerunning@gmail.com)'
-    return {
-        'User-Agent': agent
-    }
+
+# ---------------------------------------------------------------------------
+# Shared headers
+# ---------------------------------------------------------------------------
+
+def getHeader() -> dict:
+    """Return the standard User-Agent header for all outgoing HTTP requests."""
+    agent = (
+        "Wikifile-transfer/1.0 "
+        "(https://wikifile-transfer.toolforge.org; 0freerunning@gmail.com)"
+    )
+    return {"User-Agent": agent}


### PR DESCRIPTION
Introduces a custom exception hierarchy, structured rotating file-based logging, standardised API error responses, and proper error tracking for asynchronous Celery tasks.

Changes
-------
exceptions.py (new)
  - WikifileTransferError as root base for all application exceptions
  - APIError(HTTPException) as base for HTTP-facing errors; subclasses: ValidationError (422), NotFoundError (404), AuthenticationError (401), UploadError (502), ExternalAPIError (502)
  - Internal exceptions: DownloadError, DatabaseError, TaskError

logging_config.py (new)
  - configure_logging() sets up a RotatingFileHandler (5 MB / 3 backups) writing to logs/app.log plus a console handler
  - Extracted from app.py so logging config lives in its own module

error_handlers.py (updated)
  - register_error_handlers() now logs HTTP errors at WARNING and unexpected exceptions at ERROR with full traceback
  - All responses follow a consistent envelope: {"success": bool, "data": {}, "errors": [...]}

app.py (updated)
  - Import and call configure_logging() from logging_config
  - Raise ValidationError / AuthenticationError / ExternalAPIError / DownloadError / DatabaseError at every failure point instead of returning manual JSON error responses
  - /api/task_status: fix PROGRESS state data (use task.info) and SUCCESS state data (use task.result); remove non-serialisable result
  - Replace bare except: clauses with specific exception types
  - Standardise response envelope to use "errors" list throughout

utils.py (updated)
  - download_image: raise DownloadError instead of returning None; specific messages for network errors, missing imageinfo, disk failures
  - process_upload: raise UploadError instead of returning None; specific messages for CSRF, network, file-read, and wiki-rejection
  - get_localized_wikitext: replace bare except with RequestException and (KeyError, IndexError) handlers; log at appropriate levels
  - All file handles opened with context managers (with open(...))

tasks.py (updated)
  - Add structured logging with task_id on every log line
  - Wrap each stage (CSRF fetch, file upload, response parse) in try/except raising TaskError so Celery marks the task FAILURE
  - File opened with context manager to prevent handle leaks
  - Remove unused import os

tests/ (new)
  - tests/conftest.py: session-scoped Flask test client with MWOAuth and Celery mocked out; auth_client fixture for authenticated routes
  - tests/test_exceptions.py: 33 tests covering inheritance chain, HTTP status codes, werkzeug compatibility, and message handling