### PR TITLE
Fix: Cleanup temporary files after upload and on failure (T415717)

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -2,57 +2,73 @@ from celeryWorker import app
 import requests
 import requests_oauthlib
 import os
+import logging
 
 @app.task(bind=True)
 def upload_image_task(self, file_path, tr_filename, src_fileext, tr_endpoint, OAuthObj):
     ses = requests_oauthlib.OAuth1(
         client_key=OAuthObj["consumer_key"],
-        client_secret= OAuthObj["consumer_secret"],
+        client_secret=OAuthObj["consumer_secret"],
         resource_owner_key=OAuthObj["key"],
         resource_owner_secret=OAuthObj["secret"]
     )
+
     self.update_state(state='PROGRESS', meta={'current': 0, 'total': 100})
-    
-    # API Parameter to get CSRF Token
-    csrf_param = {
-        "action": "query",
-        "meta": "tokens",
-        "format": "json"
-    }
 
-    response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses)
-    csrf_token = response.json()["query"]["tokens"]["csrftoken"]
-
-    self.update_state(state='PROGRESS', meta={'current': 25, 'total': 100})
-
-    # API Parameter to upload the file
-    upload_param = {
-        "action": "upload",
-        "filename": tr_filename + "." + src_fileext,
-        "format": "json",
-        "token": csrf_token,
-        "ignorewarnings": 1
-    }
-
-    # Read the file for POST request
-    file = {
-        'file': open(file_path, 'rb')
-    }
-
-    response = requests.post(url=tr_endpoint, files=file, data=upload_param, auth=ses).json()
-
-    self.update_state(state='PROGRESS', meta={'current': 75, 'total': 100})
-
-    # Try block to get Link and URL
     try:
-        wikifile_url = response["upload"]["imageinfo"]["descriptionurl"]
-        file_link = response["upload"]["imageinfo"]["url"]
-    except KeyError:
-        return {"success": False, "data": {}, "errors": ["Upload failed"]}
+        # API Parameter to get CSRF Token
+        csrf_param = {
+            "action": "query",
+            "meta": "tokens",
+            "format": "json"
+        }
 
-    self.update_state(state='PROGRESS', meta={'current': 100, 'total': 100})
+        response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses)
+        csrf_token = response.json()["query"]["tokens"]["csrftoken"]
 
-    return {
-        "wikipage_url": wikifile_url,
-        "file_link": file_link
-    }
+        self.update_state(state='PROGRESS', meta={'current': 25, 'total': 100})
+
+        # API Parameter to upload the file
+        upload_param = {
+            "action": "upload",
+            "filename": tr_filename + "." + src_fileext,
+            "format": "json",
+            "token": csrf_token,
+            "ignorewarnings": 1
+        }
+
+        # SAFE FILE HANDLING
+        with open(file_path, 'rb') as f:
+            file = {'file': f}
+
+            response = requests.post(
+                url=tr_endpoint,
+                files=file,
+                data=upload_param,
+                auth=ses
+            ).json()
+
+        self.update_state(state='PROGRESS', meta={'current': 75, 'total': 100})
+
+        # Try block to get Link and URL
+        try:
+            wikifile_url = response["upload"]["imageinfo"]["descriptionurl"]
+            file_link = response["upload"]["imageinfo"]["url"]
+        except KeyError:
+            return {"success": False, "data": {}, "errors": ["Upload failed"]}
+
+        self.update_state(state='PROGRESS', meta={'current': 100, 'total': 100})
+
+        return {
+            "wikipage_url": wikifile_url,
+            "file_link": file_link
+        }
+
+    finally:
+        # ALWAYS CLEAN TEMP FILE
+        if os.path.exists(file_path):
+            try:
+                os.remove(file_path)
+                logging.info(f"Deleted temp file: {file_path}")
+            except Exception as e:
+                logging.error(f"Error deleting temp file {file_path}: {e}")

--- a/utils.py
+++ b/utils.py
@@ -35,44 +35,56 @@ def download_image(src_project, src_lang, src_filename):
     return filename
 
 
+import os
+
 def process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses):
-    # API Parameter to get CSRF Token
-    csrf_param = {
-        "action": "query",
-        "meta": "tokens",
-        "format": "json"
-    }
-
-    response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses)
-    csrf_token = response.json()["query"]["tokens"]["csrftoken"]
-
-    # API Parameter to upload the file
-    upload_param = {
-        "action": "upload",
-        "filename": tr_filename + "." + src_fileext,
-        "format": "json",
-        "token": csrf_token,
-        "ignorewarnings": 1
-    }
-
-    # Read the file for POST request
-    file = {
-        'file': open(file_path, 'rb')
-    }
-
-    response = requests.post(url=tr_endpoint, files=file, data=upload_param, auth=ses).json()
-
-    # Try block to get Link and URL
     try:
-        wikifile_url = response["upload"]["imageinfo"]["descriptionurl"]
-        file_link = response["upload"]["imageinfo"]["url"]
-    except KeyError:
-        return None
+        # API Parameter to get CSRF Token
+        csrf_param = {
+            "action": "query",
+            "meta": "tokens",
+            "format": "json"
+        }
 
-    return {
-        "wikipage_url": wikifile_url,
-        "file_link": file_link
-    }
+        response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses)
+        csrf_token = response.json()["query"]["tokens"]["csrftoken"]
+
+        # API Parameter to upload the file
+        upload_param = {
+            "action": "upload",
+            "filename": tr_filename + "." + src_fileext,
+            "format": "json",
+            "token": csrf_token,
+            "ignorewarnings": 1
+        }
+
+        # SAFE FILE HANDLING
+        with open(file_path, 'rb') as f:
+            file = {'file': f}
+
+            response = requests.post(
+                url=tr_endpoint,
+                files=file,
+                data=upload_param,
+                auth=ses
+            ).json()
+
+        # Try block to get Link and URL
+        try:
+            wikifile_url = response["upload"]["imageinfo"]["descriptionurl"]
+            file_link = response["upload"]["imageinfo"]["url"]
+        except KeyError:
+            return None
+
+        return {
+            "wikipage_url": wikifile_url,
+            "file_link": file_link
+        }
+
+    finally:
+        # ALWAYS CLEANUP TEMP FILE
+        if os.path.exists(file_path):
+            os.remove(file_path)
 
 
 def get_localized_wikitext(wikitext, src_endpoint, target_lang):


### PR DESCRIPTION
Summary:
This PR fixes the issue where temporary files in the temp_images directory are not cleaned up after upload or on failure.

Changes:
- Added cleanup logic in process_upload and upload_image_task
- Ensured cleanup runs using a finally block
- Used safe file handling with context managers

Why:
Temporary files were accumulating in temp_images, leading to unnecessary storage usage and potential system issues.

Testing:
- Verified files are deleted after successful upload
- Verified files are deleted after failed upload