### PR TITLE
Ensure temporary files are cleaned up after upload process

### DIFF
--- a/app.py
+++ b/app.py
@@ -92,17 +92,22 @@ def upload():
 
             if file_size < 50 * 1024 * 1024:  # 50 MB
                 # Process synchronously
-                resp = process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses)
-                if resp is None:
-                    return jsonify({"success": False, "data": {}, "errors": ["Upload failed"]}), 500
+                # Temp File Cleanup micro task T415717
+                try:
+                    resp = process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses)
+                    if resp is None:
+                        return jsonify({"success": False, "data": {}, "errors": ["Upload failed"]}), 500
 
-                resp["source"] = src_url
+                    resp["source"] = src_url
 
-                return jsonify({
-                    "success": True,
-                    "data": resp,
-                    "errors": []
-                }), 200
+                    return jsonify({
+                        "success": True,
+                        "data": resp,
+                        "errors": []
+                    }), 200
+                finally:
+                    if os.path.exists(file_path):
+                        os.remove(file_path)
             else:
                 # Process asynchronously using Celery
                 OAuthObj = {


### PR DESCRIPTION
## Related Task
https://phabricator.wikimedia.org/T415717

## Problem
Temporary files created during the upload process are not always cleaned up, especially in failure scenarios. This can lead to storage issues and resource leaks over time.

## Solution
This PR ensures that temporary files are always cleaned up after the upload process by using a finally block.

### Changes made:
- Wrapped synchronous upload logic in a try-finally block
- Ensured temporary files are deleted using os.remove()
- Added safety check using os.path.exists()

## Benefits
- Prevents accumulation of temporary files
- Improves system reliability
- Ensures proper resource management.
