### PR TITLE
fix(api): improve error handling and add timeouts to edit_page endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -269,7 +269,12 @@ def editPage():
         targetUrl = data.get('targetUrl')
         content = data.get('content')
 
+        if not targetUrl or not content:
+            return jsonify({ "success": False, "data": {}, "errors": ["Missing targetUrl or content"]}), 400
+
         match = re.findall(r"(\w+)\.(\w+)\.org/wiki/", targetUrl)
+        if not match:
+            return jsonify({ "success": False, "data": {}, "errors": ["Invalid targetUrl format"]}), 400
 
         target_project = match[0][1]
         target_lang = match[0][0]
@@ -279,6 +284,9 @@ def editPage():
 
         # Authenticate Session
         ses = authenticated_session()
+        
+        if not ses:
+            return jsonify({ "success": False, "data": {}, "errors": ["Authentication Required"]}), 401
 
         # API Parameter to get CSRF Token
         csrf_param = {
@@ -287,19 +295,31 @@ def editPage():
             "format": "json"
         }
 
-        response = requests.get(url=target_endpoint, params=csrf_param, auth=ses)
-        csrf_token = response.json()["query"]["tokens"]["csrftoken"]
+        try:
+            response = requests.get(url=target_endpoint, params=csrf_param, auth=ses, timeout=10)
+            response.raise_for_status()
+            csrf_token = response.json().get("query", {}).get("tokens", {}).get("csrftoken")
+            if not csrf_token:
+                raise ValueError("CSRF token not found in response")
+        except Exception as e:
+            logger.error(f"Failed to fetch CSRF token: {e}")
+            return jsonify({ "success": False, "data": {}, "errors": ["Failed to fetch CSRF token"]}), 502
 
         # API Parameters to edit the page
         edit_params = {
             "action": "edit",
-            "title": "File:" + target_filename.split(':')[1],
+            "title": "File:" + target_filename.split(':')[1] if ':' in target_filename else "File:" + target_filename,
             "token": csrf_token,
             "format": "json",
             "appendtext": content
         }
 
-        response = requests.post(url=target_endpoint, data=edit_params, auth=ses)
+        try:
+            response = requests.post(url=target_endpoint, data=edit_params, auth=ses, timeout=10)
+            response.raise_for_status()
+        except Exception as e:
+            logger.error(f"Failed to edit file on Wiki: {e}")
+            return jsonify({ "success": False, "data": {}, "errors": ["Edit Error"]}), 502
 
         if response.status_code == 200:
             return jsonify({ "success": True, "data": {}, "errors": []}), 200


### PR DESCRIPTION
## Problem
The current `/api/edit_page` endpoint does not do input validation and assumes that `targetUrl` is always in the correct format. If it is malformed or missing, `re.findall` and the regex matcher crash the backend with an `IndexError` or `TypeError`. Furthermore, the `requests` library calls are made with no `timeout`, risking the server hanging indefinitely if the wikimedia API is temporarily unreachable.

## Solution
This PR hardens the `/api/edit_page` code natively.
- Added strict presence and format validation to `requestURL` and `content`.
- Implemented `timeout=10` on target API fetch and pushes.
- Handles missing token retrieval gracefully instead of unhandled downstream exceptions.

### Related Tasks
Adresses the Backend Error Handling & Observability micro-task goals outline in **T415715**.
