### PR TITLE
Add multi-language upload support and article editing setup

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,8 +15,9 @@ import urllib.parse
 from model import db, User
 import logging
 from celeryWorker import app as celery_app
-from tasks import upload_image_task
+from tasks import upload_image_task, upload_task_item
 from celery.result import AsyncResult
+from utils import download_image, get_localized_wikitext, getHeader, process_upload, process_task_item
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -117,6 +118,69 @@ def upload():
             return jsonify({"success": False, "data": {}, "errors": ["Not enough data"]}), 400
     else:
         return jsonify({"success": False, "data": {}, "errors": ["Invalid Request"]}), 400
+
+
+@app.route('/api/upload_multi', methods=['POST'])
+def upload_multi():
+    if request.method == 'POST':
+        data = request.get_json()
+        src_url = urllib.parse.unquote(data.get('srcUrl', ''))
+        match = re.findall(r"(\w+)\.(\w+)\.org/wiki/", src_url)
+
+        if not match:
+            return jsonify({"status": "FAILURE", "errors": ["Invalid source URL"]}), 400
+
+        src_project = match[0][1]
+        src_lang = match[0][0]
+        src_filename = src_url.split('/')[-1]
+        src_fileext = src_filename.split('.')[-1]
+
+        # Downloading the source file and getting saved file name
+        downloaded_filename = download_image(src_project, src_lang, src_filename)
+
+        # Getting Target Details
+        tr_project = data.get('trproject')
+        tasks = data.get('tasks', [])
+
+        # Authenticate Session
+        ses = authenticated_session()
+
+        # Check whether we have enough data or not
+        if None not in (downloaded_filename, tr_project, src_fileext, ses) and len(tasks) > 0:
+            file_path = 'temp_images/' + downloaded_filename
+            file_size = os.path.getsize(file_path)
+            num_transfers = len(tasks)
+
+            # Process synchronously if only 1 target and file is lightweight
+            if file_size < 50 * 1024 * 1024 and num_transfers == 1:
+                task_item = tasks[0]
+                lang = task_item.get("lang")
+                
+                resp = process_task_item(file_path, tr_project, task_item, src_fileext, ses)
+                if resp is None:
+                    return jsonify({"status": "FAILURE", "lang": lang, "errors": [f"Upload failed for {lang}"]}), 500
+
+                return jsonify({"status": "SUCCESS", "lang": lang, "data": {lang: resp}}), 200
+            else:
+                # Process asynchronously using Celery for multiple transfers
+                OAuthObj = {
+                    "consumer_key": CONSUMER_KEY,
+                    "consumer_secret": CONSUMER_SECRET,
+                    "key": session['mwoauth_access_token']['key'],
+                    "secret": session['mwoauth_access_token']['secret']
+                }
+                
+                pending_tasks = {}
+                for task_item in tasks:
+                    lang = task_item.get("lang")
+                    task = upload_task_item.delay(file_path, tr_project, task_item, src_fileext, OAuthObj)
+                    pending_tasks[lang] = task.id
+                    
+                return jsonify({"status": "PENDING", "tasks": pending_tasks}), 202
+        else:
+            return jsonify({"status": "FAILURE", "errors": ["Not enough data or missing tasks"]}), 400
+    else:
+        return jsonify({"status": "FAILURE", "errors": ["Invalid Request"]}), 400
 
 
 @app.route('/api/preference', methods = ['GET', 'POST'])
@@ -246,7 +310,7 @@ def get_wikitext():
     }
 
     try:
-        response = requests.get(src_endpoint, params=content_params)
+        response = requests.get(src_endpoint, params=content_params, headers=getHeader())
         response.raise_for_status()
 
         page_data = response.json().get("query", {}).get("pages", [])
@@ -287,7 +351,7 @@ def editPage():
             "format": "json"
         }
 
-        response = requests.get(url=target_endpoint, params=csrf_param, auth=ses)
+        response = requests.get(url=target_endpoint, params=csrf_param, auth=ses, headers=getHeader())
         csrf_token = response.json()["query"]["tokens"]["csrftoken"]
 
         # API Parameters to edit the page
@@ -299,7 +363,7 @@ def editPage():
             "appendtext": content
         }
 
-        response = requests.post(url=target_endpoint, data=edit_params, auth=ses)
+        response = requests.post(url=target_endpoint, data=edit_params, auth=ses, headers=getHeader())
 
         if response.status_code == 200:
             return jsonify({ "success": True, "data": {}, "errors": []}), 200
@@ -317,21 +381,36 @@ def get_base_variables():
         "username": MW_OAUTH.get_current_user(True)
     }), 200
 
+
 @app.route('/api/task_status/<task_id>', methods=['GET'])
 def get_task_status(task_id):
     """
     Endpoint to get the status and result of a Celery task.
     """
     task = AsyncResult(task_id, app=celery_app)
+    
+    status = task.status
+    result = task.result if task.successful() else None
+    error = None
+    
+    # Identify PARTIAL success requirement for the frontend
+    # Triggers if file uploaded correctly, but target article update failed.
+    if task.successful() and isinstance(result, dict):
+        if result.get("article_edit_success") is False:
+            status = "PARTIAL"
+            error = "Upload completed, but failed to edit the target article (No empty image parameter in template found, or API issue)."
+
+    if task.failed():
+        error = str(task.result)
+
     response = {
         "task_id": task_id,
-        "status": task.status,
-        "result": task.result if task.successful() else None,
+        "status": status,
+        "result": result,
     }
     
-    # If task failed, include error information
-    if task.failed():
-        response["error"] = str(task.result)
+    if error:
+        response["error"] = error
 
     return jsonify(response), 200
 

--- a/frontend/custom-commands.d.ts
+++ b/frontend/custom-commands.d.ts
@@ -20,7 +20,7 @@ declare namespace Cypress {
     stubTaskStatus(taskId: string, fixturePath: string): Chainable<any>;
 
     /**
-     * Stubs the /api/upload endpoint
+     * Stubs the /api/upload_multi endpoint
      * Alias: @uploadFile
      */
     stubUpload(fixturePath: string, statusCode?: number): Chainable<any>;
@@ -37,4 +37,5 @@ declare module '*/cypress/support/utils' {
   export function visitHashRoute(route?: string): void;
   export function selectMuiDropdown(labelText: string, optionText: string): void;
   export function typeInMuiInput(labelText: string, textToType: string): void;
+  export function selectMuiMultiDropdownOptions(labelText: string, optionTexts: string[]): void;
 }

--- a/frontend/cypress/e2e/05-upload-workflow/async-upload.cy.js
+++ b/frontend/cypress/e2e/05-upload-workflow/async-upload.cy.js
@@ -1,36 +1,110 @@
+// Tests the asynchronous (HTTP 202) upload path with per-language
+// task polling. Covers PENDING → SUCCESS transitions, FAILURE error
+// panels, and PARTIAL success warnings.
+
 import { visitHashRoute, typeInMuiInput } from '../../support/utils';
 
 describe('Upload Workflow: Asynchronous (Polling)', () => {
-  const URL = 'https://en.wikipedia.org/wiki/File:Massive_File.jpg';
-  const TASK_ID = 'test-task-123';
+  const SOURCE_URL = 'https://en.wikipedia.org/wiki/File:AsyncTest.jpg';
+  const TASK_ID_EN = 'test-task-en-123';
 
   beforeEach(() => {
     cy.stubAppBoot();
     cy.setAuthState(true);
     cy.stubWikimediaFileCheck(false);
-    cy.intercept('GET', '**/api/preference', { fixture: 'user/preferences-skip.json' });
-    cy.stubUpload('upload/success-async-202.json', 202);
-    cy.intercept('GET', '**/api/get_wikitext**', { fixture: 'upload/wikitext-template.json' }).as('getWikitext');
+    cy.intercept('GET', '**/api/get_wikitext**', { fixture: 'upload/wikitext-template.json' }).as('getWikiText');
   });
 
-  it('polls task status until SUCCESS and transitions to Step 4', () => {
+  /**
+   * Navigates through all 5 upload steps and triggers the upload action.
+   * Assumes stubs for wikimedia file check, wikitext, and upload are configured.
+   */
+  const navigateAllStepsAndUpload = () => {
+    // Step 0: Enter source URL
+    typeInMuiInput('Enter Source URL', SOURCE_URL);
+    cy.contains('button', /next/i).click();
+
+    // Step 1: Pre-populated from default preferences (wikipedia, en)
+    cy.contains('label', /select project/i).should('be.visible');
+    cy.contains('button', /next/i).click();
+
+    // Step 2: Target file name auto-populated from URL
+    cy.contains('label', /Name of the Target file/i).should('be.visible');
+    cy.contains('button', /next/i).click();
+    cy.wait('@wikimediaFileCheck');
+
+    // Step 3: Template — advance
+    cy.get('textarea').should('be.visible');
+    cy.contains('button', /next/i).click();
+
+    // Step 4: Click upload
+    cy.contains('button', /upload file to target wiki/i).click();
+    cy.wait('@uploadFile');
+  };
+
+  it('polls task status PENDING → SUCCESS → displays result screen', () => {
+    cy.stubUpload('upload/success-async-202.json', 202);
+
+    // First poll returns PENDING
+    cy.intercept('GET', `**/api/task_status/${TASK_ID_EN}`, {
+      fixture: 'upload/task-status-pending.json'
+    }).as('taskPending');
+
     visitHashRoute('/upload');
+    navigateAllStepsAndUpload();
 
-    // Due to preferences-skip.json, this will jump directly from Step 1 to Step 3
-    typeInMuiInput('Source URL', URL);
-    cy.contains('button', /Next/i).click();
-    
-    cy.contains('Name of the Target file').should('be.visible');
-    
-    // 1st Poll -> Pending
-    cy.stubTaskStatus(TASK_ID, 'upload/task-status-pending.json');
-    cy.contains('button', /Upload file/i).click();
-    cy.get('[role="progressbar"]').should('be.visible');
+    // Wait for the PENDING poll, then switch intercept to SUCCESS
+    cy.wait('@taskPending');
+    cy.intercept('GET', `**/api/task_status/${TASK_ID_EN}`, {
+      fixture: 'upload/task-status-success.json'
+    }).as('taskSuccess');
 
-    // 2nd Poll -> Success
-    cy.stubTaskStatus(TASK_ID, 'upload/task-status-success.json');
-    
-    cy.wait('@getWikitext');
-    cy.get('textarea').first().should('exist'); 
+    // Wait for the SUCCESS poll to complete — once all tasks resolve,
+    // the next polling interval sets showResult=true and renders results
+    cy.wait('@taskSuccess');
+
+    // Result screen should appear with upload details
+    cy.contains('View Wiki Page').should('be.visible');
+    cy.get('img[alt="Uploaded File"]').should('be.visible');
+  });
+
+  it('displays failure panel when async task returns FAILURE status', () => {
+    cy.stubUpload('upload/success-async-202.json', 202);
+
+    // Return FAILURE on the first poll
+    cy.intercept('GET', `**/api/task_status/${TASK_ID_EN}`, {
+      fixture: 'upload/task-status-failure.json'
+    }).as('taskFailed');
+
+    visitHashRoute('/upload');
+    navigateAllStepsAndUpload();
+
+    // Wait for the FAILURE poll
+    cy.wait('@taskFailed');
+
+    // Verify the red failure error panel is rendered
+    cy.contains('Upload failed').should('be.visible');
+    cy.contains('Upload processing failed: file too large').should('be.visible');
+  });
+
+  it('displays partial-success warning when async task returns PARTIAL status', () => {
+    cy.stubUpload('upload/success-async-202.json', 202);
+
+    // Return PARTIAL on the first poll
+    cy.intercept('GET', `**/api/task_status/${TASK_ID_EN}`, {
+      fixture: 'upload/task-status-partial.json'
+    }).as('taskPartial');
+
+    visitHashRoute('/upload');
+    navigateAllStepsAndUpload();
+
+    // Wait for the PARTIAL poll
+    cy.wait('@taskPartial');
+
+    // Verify partial success warning panel and the underlying success content
+    cy.contains('Partial success').should('be.visible');
+    cy.contains('Template could not be applied').should('be.visible');
+    // File preview should still be rendered below the warning
+    cy.get('img[alt="Uploaded File"]').should('be.visible');
   });
 });

--- a/frontend/cypress/e2e/05-upload-workflow/sync-upload.cy.js
+++ b/frontend/cypress/e2e/05-upload-workflow/sync-upload.cy.js
@@ -1,7 +1,11 @@
-import { visitHashRoute, typeInMuiInput, selectMuiDropdown } from '../../support/utils';
+// Tests the synchronous (HTTP 200) upload path across the 5-step
+// multi-language workflow: single-language, multi-language, and
+// skip-upload-selection preference.
+
+import { visitHashRoute, typeInMuiInput, selectMuiMultiDropdownOptions } from '../../support/utils';
 
 describe('Upload Workflow: Synchronous', () => {
-  const URL = 'https://en.wikipedia.org/wiki/File:Example.jpg';
+  const SOURCE_URL = 'https://en.wikipedia.org/wiki/File:Example.jpg';
 
   beforeEach(() => {
     cy.stubAppBoot();
@@ -9,26 +13,102 @@ describe('Upload Workflow: Synchronous', () => {
     cy.stubWikimediaFileCheck(false);
     cy.stubUpload('upload/success-sync.json');
     cy.intercept('GET', '**/api/get_wikitext**', { fixture: 'upload/wikitext-template.json' }).as('getWikiText');
-    cy.intercept('POST', '**/api/edit_page', { statusCode: 200 }).as('editPage');
-    
-    visitHashRoute('/upload');
+    // NOTE: visitHashRoute is called inside each test (not here) so that
+    // tests like skip-upload-selection can override intercepts before the
+    // first page load.
   });
 
-  it('completes the full 4-step upload process', () => {
-    typeInMuiInput('Source URL', URL);
-    cy.contains('button', /Next/i).click();
+  it('completes the full 5-step single-language upload → shows result screen with file preview and actions', () => {
+    visitHashRoute('/upload');
 
-    selectMuiDropdown('Select project', 'Wiktionary');
-    cy.contains('button', /Next/i).click();
+    // Step 0: Enter source URL
+    typeInMuiInput('Enter Source URL', SOURCE_URL);
+    cy.contains('button', /next/i).click();
 
-    cy.get('input[type="text"]').last().should('have.value', 'Example');
-    cy.contains('button', /Upload file/i).click();
+    // Step 1: Project (wikipedia) and Language (en) pre-selected via default preferences
+    cy.contains('label', /select project/i).should('be.visible');
+    cy.contains('button', /next/i).click();
 
+    // Step 2: Verify target file name was auto-populated from the source URL
+    cy.contains('label', /Name of the Target file/i).should('be.visible');
+    cy.get('input[type="text"]').should('have.value', 'Example');
+    cy.contains('button', /next/i).click();
+    cy.wait('@wikimediaFileCheck');
+
+    // Step 3: Template step — checkbox checked by default, textarea has fetched wikitext
+    cy.get('textarea').should('be.visible');
     cy.wait('@getWikiText');
-    cy.get('textarea').first().should('contain.text', '== Description ==');
-    
-    cy.contains('button', 'Finish with edit').click();
-    cy.wait('@editPage');
+    cy.get('textarea').first().invoke('val').should('contain', '== Description ==');
+    cy.contains('button', /next/i).click();
+
+    // Step 4: Edit Article step — leave unchecked, click upload
+    cy.contains('button', /upload file to target wiki/i).should('be.visible');
+    cy.contains('button', /upload file to target wiki/i).click();
+    cy.wait('@uploadFile');
+
+    // Result screen: verify upload success toast, file preview, filename in disabled input, and action buttons
+    cy.contains('Upload successful').should('be.visible');
+    cy.get('img[alt="Uploaded File"]').should('be.visible');
+    // The filename is displayed inside a disabled MUI TextField (input value, not text content)
+    cy.get('input:disabled').should('have.value', 'TestImage.jpg');
     cy.contains('View Wiki Page').should('be.visible');
+    cy.contains('Go Back to Home').should('be.visible');
+  });
+
+  it('completes a 2-language upload (en + hi) → result screen shows per-language tabs', () => {
+    visitHashRoute('/upload');
+
+    // Override with multi-language success fixture
+    cy.stubUpload('upload/success-sync-multi.json');
+
+    // Step 0: Enter source URL
+    typeInMuiInput('Enter Source URL', SOURCE_URL);
+    cy.contains('button', /next/i).click();
+
+    // Step 1: Add Hindi alongside the pre-selected English
+    selectMuiMultiDropdownOptions('Select language', ['हिन्दी']);
+    cy.contains('button', /next/i).click();
+
+    // Step 2: Verify language tabs appear for both en and hi
+    cy.contains('[role="tab"]', 'ENGLISH').should('be.visible');
+    cy.contains('[role="tab"]', 'हिन्दी').should('be.visible');
+    // English tab is active by default — verify auto-populated file name
+    cy.get('input[type="text"]').should('have.value', 'Example');
+    // Switch to Hindi tab and verify the same auto-populated file name
+    cy.contains('[role="tab"]', 'हिन्दी').click();
+    cy.get('input[type="text"]').should('have.value', 'Example');
+    cy.contains('button', /next/i).click();
+    // Wait for file existence checks — one per language
+    cy.wait('@wikimediaFileCheck');
+    cy.wait('@wikimediaFileCheck');
+
+    // Step 3: Template — advance
+    cy.get('textarea').should('be.visible');
+    cy.contains('button', /next/i).click();
+
+    // Step 4: Upload
+    cy.contains('button', /upload file to target wiki/i).click();
+    cy.wait('@uploadFile');
+
+    // Result screen: verify per-language tabs and success content
+    cy.contains('[role="tab"]', 'ENGLISH').should('be.visible');
+    cy.contains('[role="tab"]', 'हिन्दी').should('be.visible');
+    cy.contains('View Wiki Page').should('be.visible');
+  });
+
+  it('skip-upload-selection preference jumps from step 0 directly to step 2 → skips project/language selection', () => {
+    // Override preferences BEFORE the first page visit so the component
+    // picks up skip_upload_selection=true on its initial mount.
+    cy.intercept('GET', '**/api/preference', { fixture: 'user/preferences-skip.json' }).as('getPrefs');
+    visitHashRoute('/upload');
+
+    // Step 0: Enter URL and click Next
+    typeInMuiInput('Enter Source URL', SOURCE_URL);
+    cy.contains('button', /next/i).click();
+
+    // Should land on step 2 (Name of Target File), not step 1
+    // The target file name label is unique to step 2 content (rendered as <label>)
+    cy.contains('label', /Name of the Target file/i).should('be.visible');
+    cy.get('input[type="text"]').should('have.value', 'Example');
   });
 });

--- a/frontend/cypress/e2e/05-upload-workflow/validation.cy.js
+++ b/frontend/cypress/e2e/05-upload-workflow/validation.cy.js
@@ -1,34 +1,112 @@
+// Tests validation rules and error handling across the 5-step multi-language
+// upload workflow introduced in the updated Upload.js.
+
 import { visitHashRoute } from '../../support/utils';
 
 describe('Upload Workflow: Validations & Errors', () => {
   beforeEach(() => {
     cy.stubAppBoot();
     cy.setAuthState(true);
-    visitHashRoute('/upload');
   });
 
-  it('prevents proceeding if URL is empty', () => {
+  it('prevents proceeding when source URL is empty → shows toast error', () => {
+    visitHashRoute('/upload');
+
+    // Step 0: attempt to advance without entering any URL
     cy.contains('button', /next/i).click();
     cy.contains('Please enter a valid source URL').should('be.visible');
   });
 
-  it('handles server 500 errors gracefully', () => {
-    cy.intercept('POST', '**/api/upload', {
+  it('prevents proceeding when URL lacks /wiki/ path → shows toast error', () => {
+    visitHashRoute('/upload');
+
+    // Step 0: enter a URL missing the required /wiki/ segment
+    cy.get('input[type="text"]').first().type('https://en.wikipedia.org/invalid/File:Test.jpg');
+    cy.contains('button', /next/i).click();
+    cy.contains('Please enter a valid source URL').should('be.visible');
+  });
+
+  it('prevents proceeding when project and language are not selected → shows toast error', () => {
+    // Override preferences with empty project and language so step 1 has nothing pre-selected
+    cy.intercept('GET', '**/api/preference', {
+      statusCode: 200,
+      body: { success: true, data: { project: '', lang: '', skip_upload_selection: false }, error: [] }
+    }).as('getPrefsEmpty');
+    visitHashRoute('/upload');
+
+    // Step 0: enter a valid URL and advance
+    cy.get('input[type="text"]').first().type('https://en.wikipedia.org/wiki/File:Test.jpg');
+    cy.contains('button', /next/i).click();
+
+    // Step 1: project and language are empty — attempting to proceed should fail
+    cy.contains('button', /next/i).click();
+    cy.contains('Please select a valid project and language').should('be.visible');
+  });
+
+  it('shows back button only on steps 1 and 2 → hidden on steps 0, 3, and 4', () => {
+    cy.stubWikimediaFileCheck(false);
+    cy.intercept('GET', '**/api/get_wikitext**', { fixture: 'upload/wikitext-template.json' }).as('getWikiText');
+    visitHashRoute('/upload');
+
+    // Step 0: no Back button should be rendered
+    cy.contains('button', /back/i).should('not.exist');
+
+    // Advance to Step 1
+    cy.get('input[type="text"]').first().type('https://en.wikipedia.org/wiki/File:Test.jpg');
+    cy.contains('button', /next/i).click();
+
+    // Step 1: Back button should be visible
+    cy.contains('label', /select project/i).should('be.visible');
+    cy.contains('button', /back/i).should('be.visible');
+    cy.contains('button', /next/i).click();
+
+    // Step 2: Back button should be visible
+    cy.contains('label', /Name of the Target file/i).should('be.visible');
+    cy.contains('button', /back/i).should('be.visible');
+    cy.contains('button', /next/i).click();
+    cy.wait('@wikimediaFileCheck');
+
+    // Step 3: Back button should NOT be rendered
+    cy.get('textarea').should('be.visible');
+    cy.contains('button', /back/i).should('not.exist');
+    cy.contains('button', /next/i).click();
+
+    // Step 4: Back button should NOT be rendered
+    cy.contains('button', /upload file to target wiki/i).should('be.visible');
+    cy.contains('button', /back/i).should('not.exist');
+  });
+
+  it('handles server 500 error on upload → shows error toast', () => {
+    cy.intercept('POST', '**/api/upload_multi', {
       statusCode: 500,
-      body: { errors: ['An error occurred during upload'] }
+      body: { errors: ['Internal server error'] }
     }).as('uploadError');
-    
+    cy.stubWikimediaFileCheck(false);
+    cy.intercept('GET', '**/api/get_wikitext**', { fixture: 'upload/wikitext-template.json' }).as('getWikiText');
+    visitHashRoute('/upload');
+
+    // Step 0: enter URL
     cy.get('input[type="text"]').first().type('https://en.wikipedia.org/wiki/File:Bad.jpg');
     cy.contains('button', /next/i).click();
 
-    // Verify we advanced to step 2 before clicking Next again
-    cy.contains(/select project/i).should('be.visible');
+    // Step 1: defaults pre-populated via preferences (wikipedia, en)
+    cy.contains('label', /select project/i).should('be.visible');
     cy.contains('button', /next/i).click();
-    
-    // Verify we advanced to step 3
-    cy.contains(/name of the target file/i).should('be.visible');
-    cy.contains('button', /Upload file/i).click();
+
+    // Step 2: target file name auto-populated from URL
+    cy.contains('label', /Name of the Target file/i).should('be.visible');
+    cy.contains('button', /next/i).click();
+    cy.wait('@wikimediaFileCheck');
+
+    // Step 3: template — advance past it
+    cy.get('textarea').should('be.visible');
+    cy.contains('button', /next/i).click();
+
+    // Step 4: click upload — should trigger the 500 error
+    cy.contains('button', /upload file to target wiki/i).click();
     cy.wait('@uploadError');
+
+    // Error toast should be displayed
     cy.contains('An error occurred during upload').should('be.visible');
   });
 });

--- a/frontend/cypress/fixtures/upload/success-async-202-multi.json
+++ b/frontend/cypress/fixtures/upload/success-async-202-multi.json
@@ -1,0 +1,4 @@
+{
+  "success": true,
+  "tasks": { "en": "test-task-en-123", "hi": "test-task-hi-456" }
+}

--- a/frontend/cypress/fixtures/upload/success-async-202.json
+++ b/frontend/cypress/fixtures/upload/success-async-202.json
@@ -1,4 +1,4 @@
 {
-    "success": true,
-    "task_id": "test-task-123"
+  "success": true,
+  "tasks": { "en": "test-task-en-123" }
 }

--- a/frontend/cypress/fixtures/upload/success-sync-multi.json
+++ b/frontend/cypress/fixtures/upload/success-sync-multi.json
@@ -4,6 +4,10 @@
     "en": {
       "wikipage_url": "https://en.wikipedia.org/wiki/File:TestImage.jpg",
       "file_link": "https://upload.wikimedia.org/wikipedia/en/a/a1/TestImage.jpg"
+    },
+    "hi": {
+      "wikipage_url": "https://hi.wikipedia.org/wiki/File:TestImage.jpg",
+      "file_link": "https://upload.wikimedia.org/wikipedia/hi/a/a1/TestImage.jpg"
     }
   }
 }

--- a/frontend/cypress/fixtures/upload/task-status-failure.json
+++ b/frontend/cypress/fixtures/upload/task-status-failure.json
@@ -1,0 +1,4 @@
+{
+  "status": "FAILURE",
+  "error": "Upload processing failed: file too large"
+}

--- a/frontend/cypress/fixtures/upload/task-status-partial.json
+++ b/frontend/cypress/fixtures/upload/task-status-partial.json
@@ -1,0 +1,8 @@
+{
+  "status": "PARTIAL",
+  "result": {
+    "wikipage_url": "https://en.wikipedia.org/wiki/File:TestImage.jpg",
+    "file_link": "https://upload.wikimedia.org/wikipedia/en/a/a1/TestImage.jpg"
+  },
+  "error": "Template could not be applied"
+}

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -1,6 +1,4 @@
 /**
- * Custom Cypress commands for WikiFile Transfer E2E tests.
- *
  * @see ../../../custom-commands.d.ts for TypeScript definitions.
  */
 
@@ -23,7 +21,7 @@ Cypress.Commands.add('stubTaskStatus', (taskId, fixturePath) => {
 });
 
 Cypress.Commands.add('stubUpload', (fixturePath, statusCode = 200) => {
-  cy.intercept('POST', '**/api/upload', { statusCode, fixture: fixturePath }).as('uploadFile');
+  cy.intercept('POST', '**/api/upload_multi', { statusCode, fixture: fixturePath }).as('uploadFile');
 });
 
 Cypress.Commands.add('stubWikimediaFileCheck', (exists = false) => {

--- a/frontend/cypress/support/utils.js
+++ b/frontend/cypress/support/utils.js
@@ -32,3 +32,23 @@ export const typeInMuiInput = (labelText, textToType) => {
     .clear()
     .type(textToType);
 };
+
+/**
+ * Helper to select options in an MUI multi-select dropdown (checkbox-based).
+ * Opens the dropdown, clicks each option, then closes it with Escape.
+ */
+export const selectMuiMultiDropdownOptions = (labelText, optionTexts) => {
+  cy.contains('label', labelText)
+    .parent()
+    .find('[role="combobox"]')
+    .click();
+
+  optionTexts.forEach((text) => {
+    cy.get('[role="listbox"] [role="option"]')
+      .contains(text)
+      .click();
+  });
+
+  // Close the multi-select dropdown
+  cy.get('body').type('{esc}');
+};

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -55,5 +55,17 @@
     "target-file-name-invalid": "Target file name contains invalid characters",
     "target-file-name-exist": "Target file name already exists at target wiki",
     "copy": "Copy",
-    "skip-selection": "Skip project and language selection during the upload step."
+    "skip-selection": "Skip project and language selection during the upload step.",
+    "enter-target-filename": "Please enter a target file name",
+    "task-failed-processing": "Task failed during processing.",
+    "validation-failed": "Validation not implemented",
+    "upload-failed": "Upload failed",
+    "upload-success": "Upload successful",
+    "processing-uploads": "Processing uploads...",
+    "partial-success": "Partial success",
+    "partial-warning-default": "Some tasks did not complete fully.",
+    "target-article-link": "Target article link",
+    "edit-article": "Edit article",
+    "uploads-completed": "Uploads completed.",
+    "max-languages": "You can select a maximum of 3 languages."
 }

--- a/frontend/src/pages/Upload.js
+++ b/frontend/src/pages/Upload.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import {
   Box,
   TextField,
@@ -12,17 +12,21 @@ import {
   FormControl,
   InputLabel,
   CircularProgress,
+  Tabs,
+  Tab,
+  Checkbox,
+  FormControlLabel,
+  ListItemText,
 } from "@mui/material";
 
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
 import projects from "../utils/projects";
-import { properCase } from "../utils/helper";
+import { properCase, parseSourceUrl } from "../utils/helper";
 import ISO6391 from "iso-639-1";
 import backendApi from "../utils/api";
 import { toast } from "react-toastify";
-import { parseSourceUrl } from "../utils/helper";
 import axios from "axios";
 
 function Upload() {
@@ -39,28 +43,56 @@ function Upload() {
 
   const [sourceUrl, setSourceUrl] = useState("");
   const [project, setProject] = useState("");
-  const [language, setLanguage] = useState("");
-  const [targetFileName, setTargetFileName] = useState("");
-  const [uploadStatus, setUploadStatus] = useState({ type: null, data: null });
-  const [pageContent, setPageContent] = useState("");
+  
+  const [languages, setLanguages] = useState([]);
+  const [languageData, setLanguageData] = useState({});
+  const [activeTabs, setActiveTabs] = useState({ 2: 0, 3: 0, 4: 0 });
+  const [successTab, setSuccessTab] = useState(0);
+
+  const [pendingTasks, setPendingTasks] = useState({});
+  const [uploadResults, setUploadResults] = useState({});
+  const pollIntervalRef = useRef(null);
+
+  const currentLangIdx = activeTabs[activeStep] || 0;
+  const currentLang = languages[currentLangIdx] || "";
+  const currentData = languageData[currentLang] || {};
+
+  const pendingLangs = Object.keys(pendingTasks);
+  
+  const validResultTab = Math.min(successTab, Math.max(0, languages.length - 1));
+  const currentResultLang = languages[validResultTab] || "";
 
   const steps = [
     t("enter-source-url"),
     t("select-project-and-language"),
     t("name-of-target-file"),
     t("add-template"),
+    t("edit-article"),
   ];
+
+  useEffect(() => {
+    return () => {
+      if (pollIntervalRef.current) {
+        clearInterval(pollIntervalRef.current);
+      }
+    };
+  }, []);
+
+  const handleLanguageDataChange = (lang, field, value) => {
+    setLanguageData((prev) => ({
+      ...prev,
+      [lang]: { ...prev[lang], [field]: value },
+    }));
+  };
 
   const handleNext = async () => {
     const isValid = await isStepValid();
-    if( activeStep === 0 && isValid === true && skipUploadSelection) {
+    if (activeStep === 0 && isValid === true && skipUploadSelection) {
       setActiveStep(2);
       return;
     }
 
-    if (activeStep === 2 && isValid === true) {
-      handleUpload();
-    } else if (isValid === true) {
+    if (isValid === true) {
       setError(null);
       setActiveStep((prevStep) => prevStep + 1);
     } else if (isValid !== true && isValid.length > 0) {
@@ -72,90 +104,105 @@ function Upload() {
     setActiveStep((prevStep) => prevStep - 1);
   };
 
-  const handleUpload = () => {
+  const handleFinish = async () => {
+    const isValid = await isStepValid();
+    if (isValid !== true && isValid.length > 0) {
+      toast.error(t(isValid));
+      return;
+    }
+
     const payload = {
       srcUrl: sourceUrl,
       trproject: project,
-      trlang: language,
-      trfilename: targetFileName,
+      tasks: languages.map((lang) => ({
+        lang: lang,
+        trfilename: languageData[lang]?.targetFileName || "",
+        addTemplate: languageData[lang]?.addTemplate !== false, 
+        pageContent: languageData[lang]?.pageContent || "",
+        editArticle: languageData[lang]?.editArticle === true,
+        articleLink: languageData[lang]?.articleLink || "",
+      })),
     };
 
-    setLoading(true);
-    backendApi
-      .post("/api/upload", payload)
-      .then((response) => {
-        if (response.status === 202) {
-          const taskId = response.data.task_id;
-          pollTaskStatus(taskId);
-        } else if (response.status === 200) {
-          setUploadStatus({ type: "success", data: response.data.data });
-          setLoading(false);
-          setError(null);
-          setActiveStep((prevStep) => prevStep + 1);
-        }
-      })
-      .catch((error) => {
+    try {
+      setLoading(true);
+      const response = await backendApi.post("/api/upload_multi", payload);
+
+      if (response.status === 200) {
+        const results = {};
+        languages.forEach((lang) => {
+          results[lang] = { status: "SUCCESS", data: response.data.data[lang] || response.data.data };
+        });
+        setUploadResults(results);
         setLoading(false);
-        setError(t("upload-error"));
-        toast.error(`${t("upload-error")}: ${error}`);
-      });
+        setShowResult(true);
+        toast.success(t("upload-success"));
+      } else if (response.status === 202) {
+        const tasks = response.data.tasks || {};
+        setPendingTasks(tasks);
+
+        const initialResults = {};
+        languages.forEach((lang) => {
+          initialResults[lang] = { status: "PENDING" };
+        });
+        setUploadResults(initialResults);
+
+        pollTaskStatus(tasks);
+      }
+    } catch (error) {
+      setLoading(false);
+      setError(t("upload-error"));
+      toast.error(`${t("upload-error")}: ${error}`);
+    }
   };
 
-  const pollTaskStatus = (taskId) => {
-    const interval = setInterval(() => {
-      backendApi
-        .get(`/api/task_status/${taskId}`)
-        .then((response) => {
+  const pollTaskStatus = (initialTasks) => {
+    let currentPendingTasks = { ...initialTasks };
+
+    pollIntervalRef.current = setInterval(async () => {
+      const pendingKeys = Object.keys(currentPendingTasks);
+
+      if (pendingKeys.length === 0) {
+        clearInterval(pollIntervalRef.current);
+        setLoading(false);
+        setError(null);
+        toast.success(t("uploads-completed"));
+        setShowResult(true);
+        return;
+      }
+
+      for (const lang of pendingKeys) {
+        const taskId = currentPendingTasks[lang];
+        try {
+          const response = await backendApi.get(`/api/task_status/${taskId}`);
           const { status, result, error } = response.data;
 
           if (status === "SUCCESS") {
-            clearInterval(interval);
-            setUploadStatus({ type: "success", data: result });
-            setLoading(false);
-            setError(null);
-            setActiveStep((prevStep) => prevStep + 1);
+            setUploadResults((prev) => ({
+              ...prev,
+              [lang]: { status: "SUCCESS", data: result },
+            }));
+            delete currentPendingTasks[lang];
+          } else if (status === "PARTIAL") {
+            setUploadResults((prev) => ({
+              ...prev,
+              [lang]: { status: "PARTIAL", data: result, warnings: error },
+            }));
+            delete currentPendingTasks[lang];
           } else if (status === "FAILURE") {
-            clearInterval(interval);
-            setLoading(false);
-            setError(error || t("task-failed-processing"));
+            setUploadResults((prev) => ({
+              ...prev,
+              [lang]: { status: "FAILURE", error: error || t("task-failed-processing") },
+            }));
+            delete currentPendingTasks[lang];
           }
-        })
-        .catch((pollError) => {
+        } catch (pollError) {
           toast.error(`${t("poll-error")}: ${pollError}`);
-        });
-    }, 2000);
-  };
-
-  const handleFinishWithoutEdit = () => {
-    setError(null);
-    setShowResult(true);
-  };
-
-  const handleFinishWithEdit = () => {
-    const payload = {
-      content: pageContent,
-      targetUrl: uploadStatus.data.wikipage_url,
-    };
-
-    setLoading(true);
-    setError(null);
-
-    backendApi
-      .post("/api/edit_page", payload)
-      .then((response) => {
-        if (response.status === 200) {
-          setError(null);
-          setShowResult(true);
-        } else {
-          setError(t("edit-error"));
         }
-        setLoading(false);
-      })
-      .catch((error) => {
-        setLoading(false);
-        setError(t("edit-error"));
-        toast.error(`${t("edit-error")}: ${error}`);
-      });
+      }
+
+      setPendingTasks({ ...currentPendingTasks });
+    }, 2000);
   };
 
   const isStepValid = async () => {
@@ -170,9 +217,10 @@ function Upload() {
       case 1:
         if (
           project !== "" &&
-          language !== "" &&
+          languages.length > 0 &&
+          languages.length <= 3 &&
           projects.hasOwnProperty(project) &&
-          projects[project].includes(language)
+          languages.every((lang) => projects[project].includes(lang))
         ) {
           return true;
         } else {
@@ -180,101 +228,119 @@ function Upload() {
         }
 
       case 2:
-        const sourceFileExt = sourceUrl.substring(
-          sourceUrl.lastIndexOf(".") + 1
-        );
+        const sourceFileExt = sourceUrl.substring(sourceUrl.lastIndexOf(".") + 1);
 
-        const apiUrl = `https://${language}.${project}.org/w/api.php?action=query&titles=File:${encodeURIComponent(
-          targetFileName
-        )}.${sourceFileExt}&format=json&origin=*`;
-        const response = await axios.get(apiUrl);
-        const pages = response.data.query.pages;
-        const pageId = Object.keys(pages)[0];
+        for (const lang of languages) {
+          const trfilename = languageData[lang]?.targetFileName;
+          if (!trfilename) return "enter-target-filename";
 
-        if (pageId === "-1") {
-          console.log(pages[pageId]);
-          if (Object.keys(pages[pageId]).includes("missing")) {
-            return true;
-          } else if (Object.keys(pages[pageId]).includes("invalidreason")) {
+          const apiUrl = `https://${lang}.${project}.org/w/api.php?action=query&titles=File:${encodeURIComponent(
+            trfilename
+          )}.${sourceFileExt}&format=json&origin=*`;
+
+          try {
+            const response = await axios.get(apiUrl);
+            const pages = response.data.query.pages;
+            const pageId = Object.keys(pages)[0];
+
+            if (pageId !== "-1") {
+              return "target-file-name-exist";
+            } else if (Object.keys(pages[pageId]).includes("invalidreason")) {
+              return "target-file-name-invalid";
+            }
+          } catch (err) {
             return "target-file-name-invalid";
           }
         }
-        return "target-file-name-exist";
+        return true;
+
+      case 3:
+        return true;
+
+      case 4:
+        // validation logic for step 5
+        for (const lang of languages) {
+          if (languageData[lang]?.editArticle) {
+            // TODO: check with wikimedia API if image param exists in template with empty url
+            return "validation-failed";
+          }
+        }
+        return true;
       default:
         return true;
     }
   };
 
   useEffect(() => {
-    const fetchPageContent = (srcLang, srcProject, srcFileName) => {
-      backendApi
-        .get("/api/get_wikitext", {
-          params: {
-            src_lang: srcLang,
-            src_project: srcProject,
-            src_filename: srcFileName,
-            tr_lang: language,
-          },
-        })
-        .then((response) => {
-          if (response.data.wikitext) {
-            setPageContent(response.data.wikitext);
-          } else {
-            toast.error(t("content-not-found"));
-          }
-        })
-        .catch((error) => {
-          toast.error(t("fetch-content-error"));
-        });
-    };
-
-    if (uploadStatus.type === "success" && uploadStatus.data) {
-      const sourceUrlObj = parseSourceUrl(sourceUrl);
-      if (sourceUrlObj) {
-        const { srcLang, srcProject, srcFileName } = sourceUrlObj;
-
-        fetchPageContent(srcLang, srcProject, srcFileName);
+    let nameWithoutExtension = "";
+    if (sourceUrl && sourceUrl.includes("/")) {
+      const fileNameWithExtension = sourceUrl.split("/").pop() || "";
+      if (fileNameWithExtension) {
+        nameWithoutExtension =
+          fileNameWithExtension.includes(":") && fileNameWithExtension.includes(".")
+            ? fileNameWithExtension.substring(
+                fileNameWithExtension.indexOf(":") + 1,
+                fileNameWithExtension.lastIndexOf(".")
+              )
+            : "";
       }
     }
-  }, [uploadStatus, sourceUrl, language, t]);
 
-  useEffect(() => {
-    if (sourceUrl) {
-      if (sourceUrl.includes("/")) {
-        const fileNameWithExtension = sourceUrl.split("/").pop() || "";
+    const sourceUrlObj = parseSourceUrl(sourceUrl);
 
-        if (fileNameWithExtension) {
-          const nameWithoutExtension =
-            fileNameWithExtension.includes(":") &&
-            fileNameWithExtension.includes(".")
-              ? fileNameWithExtension.substring(
-                  fileNameWithExtension.indexOf(":") + 1,
-                  fileNameWithExtension.lastIndexOf(".")
-                )
-              : "";
-          if (nameWithoutExtension) {
-            setTargetFileName(nameWithoutExtension);
-          }
-        } else {
-          setTargetFileName("");
+    setLanguageData((prev) => {
+      const newData = { ...prev };
+      let stateChanged = false;
+
+      languages.forEach((lang) => {
+        if (!newData[lang]) {
+          newData[lang] = {};
         }
-      } else {
-        setTargetFileName("");
-      }
-    } else {
-      setTargetFileName("");
-    }
-  }, [sourceUrl]);
+
+        if (nameWithoutExtension && !newData[lang].targetFileName) {
+          newData[lang].targetFileName = nameWithoutExtension;
+          stateChanged = true;
+        }
+
+        if (newData[lang].pageContent === undefined && sourceUrlObj) {
+          newData[lang].pageContent = ""; 
+          stateChanged = true;
+
+          backendApi
+            .get("/api/get_wikitext", {
+              params: {
+                src_lang: sourceUrlObj.srcLang,
+                src_project: sourceUrlObj.srcProject,
+                src_filename: sourceUrlObj.srcFileName,
+                tr_lang: lang,
+              },
+            })
+            .then((response) => {
+              if (response.data.wikitext) {
+                handleLanguageDataChange(lang, "pageContent", response.data.wikitext);
+              }
+            })
+            .catch(() => {
+              // Failure to fetch wikitext
+            });
+        }
+      });
+
+      return stateChanged ? newData : prev;
+    });
+  }, [sourceUrl, languages]);
 
   useEffect(() => {
-    setAvailableLanguages(projects[project]);
+    setAvailableLanguages(projects[project] || []);
   }, [project]);
 
   useEffect(() => {
     backendApi.get("/api/preference").then((response) => {
       setProject(response.data.data.project);
-      setLanguage(response.data.data.lang);
-      setAvailableLanguages(projects[response.data.data.project]);
+      if (response.data.data.lang) {
+        setLanguages([response.data.data.lang]);
+      }
+      setAvailableLanguages(projects[response.data.data.project] || []);
       setSkipUploadSelection(response.data.data.skip_upload_selection);
     });
   }, []);
@@ -292,107 +358,161 @@ function Upload() {
       )}
 
       {error && (
-        <Typography
-          color="error"
-          variant="body2"
-          sx={{ textAlign: "center", mt: 2 }}
-        >
+        <Typography color="error" variant="body2" sx={{ textAlign: "center", mt: 2 }}>
           {error}
         </Typography>
       )}
 
       {showResult ? (
         <Box textAlign="center">
-          <Box mt={2}>
-            <img
-              src={uploadStatus.data.file_link}
-              alt="Uploaded File"
-              style={{ maxWidth: "100%" }}
-              height={380}
-              width={260}
-            />
-            <Box display="flex" justifyContent="center" mt={2}>
-              <TextField
-                style={{ width: "650px" }}
-                value={decodeURIComponent(uploadStatus.data.wikipage_url)
-                  .split("/")
-                  .pop()}
-                disabled={true}
-                slotProps={{
-                  input: {
-                    endAdornment: (
-                      <Button
-                        variant="contained"
-                        color="primary"
-                        onClick={() =>
-                          navigator.clipboard.writeText(
-                            decodeURIComponent(uploadStatus.data.wikipage_url)
-                              .split("/")
-                              .pop()
-                          )
-                        }
-                      >
-                        {t("copy")}
-                      </Button>
-                    ),
-                  },
-                }}
-              />
+          {pendingLangs.length > 0 ? (
+            <Box mt={5} mb={5}>
+              <CircularProgress />
+              <Typography mt={2}>
+                {/* Changed to show exact progress numbers */}
+                {t("processing-uploads")} ({languages.length - pendingLangs.length} / {languages.length})
+              </Typography>
             </Box>
-            <Box display="flex" justifyContent="center" mt={2}>
-              <Button
-                variant="contained"
-                color="primary"
-                href={uploadStatus.data.wikipage_url}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {t("view-wiki-page")}
-              </Button>
-              <Button
-                variant="contained"
-                color="secondary"
-                sx={{ ml: 2 }}
-                onClick={() => navigate("/")}
-              >
-                {t("go-back-to-home")}
-              </Button>
-            </Box>
-          </Box>
-        </Box>
-      ) : activeStep === steps.length - 1 ? (
-        <Box textAlign="center">
-          <TextField
-            label={t("source-url-label")}
-            multiline
-            rows={10}
-            fullWidth
-            margin="normal"
-            value={pageContent}
-            onChange={(e) => setPageContent(e.target.value)}
-          />
-          <Box display="flex" justifyContent="center" mt={2}>
-            <Button
-              variant="contained"
-              onClick={handleFinishWithoutEdit}
-              disabled={loading}
-              sx={{
-                backgroundColor: "red",
-                "&:hover": { backgroundColor: "darkred" },
-              }}
-            >
-              {t("finish-without-edit")}
-            </Button>
-            <Button
-              color="primary"
-              variant="contained"
-              onClick={handleFinishWithEdit}
-              disabled={loading}
-              sx={{ ml: 2 }}
-            >
-              {t("finish-with-edit")}
-            </Button>
-          </Box>
+          ) : (
+            <>
+              {/* Changed Tabs to iterate overall selected languages and apply status colors */}
+              <Tabs value={validResultTab} onChange={(e, val) => setSuccessTab(val)} centered>
+                {languages.map((lang, idx) => (
+                  <Tab 
+                    key={lang} 
+                    label={(ISO6391.getNativeName(lang) || lang).toUpperCase()} 
+                    value={idx} 
+                    sx={{
+                      color:
+                        uploadResults[lang]?.status === "SUCCESS"
+                          ? "success.main"
+                          : uploadResults[lang]?.status === "PARTIAL"
+                          ? "warning.main"
+                          : uploadResults[lang]?.status === "FAILURE"
+                          ? "error.main"
+                          : "inherit",
+                    }}
+                  />
+                ))}
+              </Tabs>
+
+              {currentResultLang && uploadResults[currentResultLang] && (
+                <Box mt={2}>
+                  {/* FAILURE PANEL: Show this strictly when language has failed */}
+                  {uploadResults[currentResultLang].status === "FAILURE" ? (
+                    <Box mt={2} p={3} border="1px solid #f5c6cb" borderRadius={2} bgcolor="#f8d7da">
+                      <Typography variant="h6" fontWeight="bold" color="error">
+                        {t("upload-failed")}
+                      </Typography>
+                      <Typography variant="body1" color="error" mt={1}>
+                        {uploadResults[currentResultLang].error || t("task-failed-processing")}
+                      </Typography>
+                    </Box>
+                  ) : (
+                    <>
+                      {/* PARTIAL WARNING PANEL: Render warnings for partial success */}
+                      {uploadResults[currentResultLang].status === "PARTIAL" && (
+                        <Box mt={2} mb={3} p={2} border="1px solid #ffeeba" borderRadius={2} bgcolor="#fff3cd">
+                          <Typography variant="subtitle1" fontWeight="bold" sx={{ color: "warning.main" }}>
+                            {t("partial-success")}
+                          </Typography>
+                          <Typography variant="body2" sx={{ color: "warning.main" }}>
+                            {uploadResults[currentResultLang].warnings || uploadResults[currentResultLang].error || t("partial-warning-default")}
+                          </Typography>
+                        </Box>
+                      )}
+
+                      {/* Article Edit Status Label for Success/Partial Screen */}
+                      {languageData[currentResultLang]?.editArticle &&
+                        uploadResults[currentResultLang].data?.article_edit_success !== undefined && (
+                          <Box mt={2} mb={3} p={2} border="1px solid #ccc" borderRadius={2} bgcolor="#f9f9f9">
+                            <Typography variant="subtitle1" fontWeight="bold">
+                              Article Update Target
+                            </Typography>
+                            <Typography variant="body2" sx={{ mb: 1 }}>
+                              <a
+                                href={languageData[currentResultLang].articleLink}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                              >
+                                {languageData[currentResultLang].articleLink}
+                              </a>
+                            </Typography>
+                            <Typography
+                              variant="body2"
+                              sx={{
+                                fontWeight: "bold",
+                                color: uploadResults[currentResultLang].data.article_edit_success
+                                  ? "green"
+                                  : "error.main",
+                              }}
+                            >
+                              Status:{" "}
+                              {uploadResults[currentResultLang].data.article_edit_success
+                                ? "Successfully updated!"
+                                : "Failed or No changes made."}
+                            </Typography>
+                          </Box>
+                        )}
+
+                      {uploadResults[currentResultLang].data && (
+                        <>
+                          <img
+                            src={uploadResults[currentResultLang].data.file_link}
+                            alt="Uploaded File"
+                            style={{ maxWidth: "100%" }}
+                            height={380}
+                            width={260}
+                          />
+                          <Box display="flex" justifyContent="center" mt={2}>
+                            <TextField
+                              style={{ width: "650px" }}
+                              value={(() => {
+                                const fileName = decodeURIComponent(uploadResults[currentResultLang].data.wikipage_url).split("/").pop();
+                                return fileName.includes(":") ? fileName.substring(fileName.indexOf(":") + 1) : fileName;
+                              })()}
+                              disabled={true}
+                              slotProps={{
+                                input: {
+                                  endAdornment: (
+                                    <Button
+                                      variant="contained"
+                                      color="primary"
+                                      onClick={() => {
+                                        const fileName = decodeURIComponent(uploadResults[currentResultLang].data.wikipage_url).split("/").pop();
+                                        const nameOnly = fileName.includes(":") ? fileName.substring(fileName.indexOf(":") + 1) : fileName;
+                                        navigator.clipboard.writeText(nameOnly);
+                                      }}
+                                    >
+                                      {t("copy")}
+                                    </Button>
+                                  ),
+                                },
+                              }}
+                            />
+                          </Box>
+                          <Box display="flex" justifyContent="center" mt={2}>
+                            <Button
+                              variant="contained"
+                              color="primary"
+                              href={uploadResults[currentResultLang].data.wikipage_url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              {t("view-wiki-page")}
+                            </Button>
+                            <Button variant="contained" color="secondary" sx={{ ml: 2 }} onClick={() => navigate("/")}>
+                              {t("go-back-to-home")}
+                            </Button>
+                          </Box>
+                        </>
+                      )}
+                    </>
+                  )}
+                </Box>
+              )}
+            </>
+          )}
         </Box>
       ) : (
         <Box>
@@ -416,12 +536,15 @@ function Upload() {
                 <Select
                   label={t("select-project")}
                   value={project}
-                  onChange={(e) => setProject(e.target.value)}
+                  onChange={(e) => {
+                    setProject(e.target.value);
+                    setLanguages([]);
+                  }}
                   disabled={loading}
                 >
-                  {Object.keys(projects).map((project) => (
-                    <MenuItem key={project} value={project}>
-                      {properCase(project)}
+                  {Object.keys(projects).map((proj) => (
+                    <MenuItem key={proj} value={proj}>
+                      {properCase(proj)}
                     </MenuItem>
                   ))}
                 </Select>
@@ -429,14 +552,25 @@ function Upload() {
               <FormControl fullWidth margin="normal">
                 <InputLabel>{t("select-language")}</InputLabel>
                 <Select
+                  multiple
                   label={t("select-language")}
-                  value={language}
-                  onChange={(e) => setLanguage(e.target.value)}
+                  value={languages}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    const selected = typeof val === "string" ? val.split(",") : val;
+                    if (selected.length <= 3) {
+                      setLanguages(selected);
+                    } else {
+                      toast.error(t("max-languages"));
+                    }
+                  }}
+                  renderValue={(selected) => selected.map((l) => ISO6391.getNativeName(l) || l).join(", ")}
                   disabled={loading}
                 >
                   {availableLanguages.map((lang) => (
                     <MenuItem key={lang} value={lang}>
-                      {ISO6391.getNativeName(lang) || lang}
+                      <Checkbox checked={languages.indexOf(lang) > -1} />
+                      <ListItemText primary={ISO6391.getNativeName(lang) || lang} />
                     </MenuItem>
                   ))}
                 </Select>
@@ -445,42 +579,121 @@ function Upload() {
           )}
 
           {activeStep === 2 && (
-            <>
-              <TextField
-                label={t("target-file-name-label")}
-                placeholder={t("target-file-name-placeholder")}
-                fullWidth
-                margin="normal"
-                value={targetFileName}
-                onChange={(e) => setTargetFileName(e.target.value)}
-                required
-                disabled={loading}
-              />
+            <Box textAlign="center">
+              <Tabs
+                value={currentLangIdx}
+                onChange={(e, val) => setActiveTabs((prev) => ({ ...prev, [activeStep]: val }))}
+                centered
+              >
+                {languages.map((lang, idx) => (
+                  <Tab key={lang} label={(ISO6391.getNativeName(lang) || lang).toUpperCase()} value={idx} />
+                ))}
+              </Tabs>
+              <Box mt={2}>
+                <TextField
+                  label={`${t("target-file-name-label")} (${currentLang})`}
+                  placeholder={t("target-file-name-placeholder")}
+                  fullWidth
+                  margin="normal"
+                  value={currentData.targetFileName || ""}
+                  onChange={(e) => handleLanguageDataChange(currentLang, "targetFileName", e.target.value)}
+                  required
+                  disabled={loading}
+                />
+              </Box>
               {loading && (
                 <Box display="flex" justifyContent="center" mt={2}>
                   <CircularProgress />
                 </Box>
               )}
-            </>
+            </Box>
           )}
 
-          {activeStep < steps.length - 1 && (
-            <Box display="flex" justifyContent="space-between" mt={2}>
-              <Button
-                disabled={activeStep === 0 || loading}
-                onClick={handleBack}
+          {activeStep === 3 && (
+            <Box textAlign="center">
+              <Tabs
+                value={currentLangIdx}
+                onChange={(e, val) => setActiveTabs((prev) => ({ ...prev, [activeStep]: val }))}
+                centered
               >
-                {t("back")}
-              </Button>
+                {languages.map((lang, idx) => (
+                  <Tab key={lang} label={(ISO6391.getNativeName(lang) || lang).toUpperCase()} value={idx} />
+                ))}
+              </Tabs>
+              <Box mt={2}>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={currentData.addTemplate !== false}
+                      onChange={(e) => handleLanguageDataChange(currentLang, "addTemplate", e.target.checked)}
+                    />
+                  }
+                  label={t("add-template")}
+                />
+                <TextField
+                  label={t("add-template")}
+                  multiline
+                  rows={10}
+                  fullWidth
+                  margin="normal"
+                  value={currentData.pageContent || ""}
+                  onChange={(e) => handleLanguageDataChange(currentLang, "pageContent", e.target.value)}
+                  disabled={currentData.addTemplate === false || loading}
+                />
+              </Box>
+            </Box>
+          )}
+
+          {activeStep === 4 && (
+            <Box textAlign="center">
+              <Tabs
+                value={currentLangIdx}
+                onChange={(e, val) => setActiveTabs((prev) => ({ ...prev, [activeStep]: val }))}
+                centered
+              >
+                {languages.map((lang, idx) => (
+                  <Tab key={lang} label={(ISO6391.getNativeName(lang) || lang).toUpperCase()} value={idx} />
+                ))}
+              </Tabs>
+              <Box mt={2}>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={currentData.editArticle === true}
+                      onChange={(e) => handleLanguageDataChange(currentLang, "editArticle", e.target.checked)}
+                    />
+                  }
+                  label={t("edit-article")}
+                />
+                <TextField
+                  label={t("target-article-link")}
+                  fullWidth
+                  margin="normal"
+                  value={currentData.articleLink || ""}
+                  onChange={(e) => handleLanguageDataChange(currentLang, "articleLink", e.target.value)}
+                  disabled={currentData.editArticle !== true || loading}
+                />
+              </Box>
+            </Box>
+          )}
+
+          {activeStep <= steps.length - 1 && (
+            <Box display="flex" justifyContent="space-between" mt={2}>
+              <Box>
+                {/* Back button strictly isolated to step 1 and 2 (0-indexed) per your requirement */}
+                {(activeStep === 1 || activeStep === 2) && (
+                  <Button disabled={loading} onClick={handleBack}>
+                    {t("back")}
+                  </Button>
+                )}
+              </Box>
               <Button
                 variant="contained"
                 color="primary"
-                onClick={handleNext}
+                onClick={activeStep === steps.length - 1 ? handleFinish : handleNext}
                 disabled={loading}
               >
-                {activeStep === steps.length - 2
-                  ? t("upload-file-to-target-wiki")
-                  : t("next")}
+                {activeStep === steps.length - 1 ? t("upload-file-to-target-wiki") : t("next")}
               </Button>
             </Box>
           )}

--- a/tasks.py
+++ b/tasks.py
@@ -1,7 +1,115 @@
 from celeryWorker import app
 import requests
 import requests_oauthlib
+import urllib.parse
 import os
+from utils import getHeader, edit_target_article
+
+@app.task(bind=True)
+def upload_task_item(self, file_path, tr_project, task_item, src_fileext, OAuthObj):
+    """
+    Celery task to handle a single language asynchronous transfer.
+    """
+    self.update_state(state='PROGRESS', meta={'current': 0, 'total': 100})
+    
+    try:
+        # 1. Reconstruct OAuth Session
+        ses = requests_oauthlib.OAuth1(
+            client_key=OAuthObj["consumer_key"],
+            client_secret=OAuthObj["consumer_secret"],
+            resource_owner_key=OAuthObj["key"],
+            resource_owner_secret=OAuthObj["secret"]
+        )
+        
+        # 2. Parse Task Parameters
+        lang = task_item.get("lang")
+        raw_tr_filename = task_item.get("trfilename", "")
+        tr_filename = urllib.parse.unquote(raw_tr_filename).strip()
+        
+        add_template = task_item.get("addTemplate", False)
+        page_content = task_item.get("pageContent", "")
+        edit_article = task_item.get("editArticle", False)
+        article_link = task_item.get("articleLink", "")
+
+        if not lang or not tr_filename:
+            raise ValueError("Missing 'lang' or 'trfilename' in task payload.")
+
+        tr_endpoint = f"https://{lang}.{tr_project}.org/w/api.php"
+
+        # 3. Fetch CSRF Token
+        csrf_param = {
+            "action": "query",
+            "meta": "tokens",
+            "format": "json"
+        }
+        
+        response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses, headers=getHeader())
+        response.raise_for_status()
+        csrf_token = response.json()["query"]["tokens"]["csrftoken"]
+        
+        self.update_state(state='PROGRESS', meta={'current': 25, 'total': 100})
+
+        # 4. Prepare Upload Parameters & Execute Upload
+        upload_param = {
+            "action": "upload",
+            "filename": f"{tr_filename}.{src_fileext}",
+            "format": "json",
+            "token": csrf_token,
+            "ignorewarnings": 1
+        }
+
+        # Add Template text as file description if checked
+        if add_template and page_content:
+            upload_param["text"] = page_content
+
+        # POST File Upload Request
+        with open(file_path, 'rb') as f:
+            files = {'file': f}
+            upload_resp = requests.post(
+                url=tr_endpoint, 
+                files=files, 
+                data=upload_param, 
+                auth=ses, 
+                headers=getHeader()
+            ).json()
+
+        # Catch API-level upload errors embedded in 200 JSON
+        if "error" in upload_resp:
+            api_err = upload_resp["error"].get("info", str(upload_resp["error"]))
+            raise Exception(f"Wikimedia API Upload Error: {api_err}")
+
+        # Extract success URLs
+        wikifile_url = upload_resp["upload"]["imageinfo"]["descriptionurl"]
+        file_link = upload_resp["upload"]["imageinfo"]["url"]
+        
+        self.update_state(state='PROGRESS', meta={'current': 75, 'total': 100})
+
+        # 5. Execute Optional Target Article Edit
+        article_edit_success = None
+        if edit_article and article_link:
+            try:
+                # Most templates just expect the filename + extension (without "File:" prefix)
+                image_title = f"{tr_filename}.{src_fileext}"
+                article_edit_success = edit_target_article(
+                    article_url=article_link, 
+                    tr_endpoint=tr_endpoint, 
+                    image_title=image_title, 
+                    csrf_token=csrf_token, 
+                    ses=ses
+                )
+            except Exception as e:
+                article_edit_success = False
+
+        self.update_state(state='PROGRESS', meta={'current': 100, 'total': 100})
+
+        return {
+            "wikipage_url": wikifile_url,
+            "file_link": file_link,
+            "article_edit_success": article_edit_success
+        }
+
+    except Exception as e:
+        raise Exception(str(e))
 
 @app.task(bind=True)
 def upload_image_task(self, file_path, tr_filename, src_fileext, tr_endpoint, OAuthObj):
@@ -12,7 +120,7 @@ def upload_image_task(self, file_path, tr_filename, src_fileext, tr_endpoint, OA
         resource_owner_secret=OAuthObj["secret"]
     )
     self.update_state(state='PROGRESS', meta={'current': 0, 'total': 100})
-    
+
     # API Parameter to get CSRF Token
     csrf_param = {
         "action": "query",
@@ -20,7 +128,7 @@ def upload_image_task(self, file_path, tr_filename, src_fileext, tr_endpoint, OA
         "format": "json"
     }
 
-    response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses)
+    response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses, headers=getHeader())
     csrf_token = response.json()["query"]["tokens"]["csrftoken"]
 
     self.update_state(state='PROGRESS', meta={'current': 25, 'total': 100})
@@ -34,12 +142,9 @@ def upload_image_task(self, file_path, tr_filename, src_fileext, tr_endpoint, OA
         "ignorewarnings": 1
     }
 
-    # Read the file for POST request
-    file = {
-        'file': open(file_path, 'rb')
-    }
+    file = {'file': open(file_path, 'rb')}
 
-    response = requests.post(url=tr_endpoint, files=file, data=upload_param, auth=ses).json()
+    response = requests.post(url=tr_endpoint, files=file, data=upload_param, auth=ses, headers=getHeader()).json()
 
     self.update_state(state='PROGRESS', meta={'current': 75, 'total': 100})
 

--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,4 @@
+import urllib.parse
 import datetime
 import requests
 import mwparserfromhell
@@ -15,7 +16,7 @@ def download_image(src_project, src_lang, src_filename):
         "iilocalonly": 1
     }
 
-    page = requests.get(url=src_endpoint, params=param).json()['query']['pages']
+    page = requests.get(url=src_endpoint, params=param, headers=getHeader()).json()['query']['pages']
 
     try:
         image_url = list (page.values()) [0]["imageinfo"][0]["url"]
@@ -24,11 +25,9 @@ def download_image(src_project, src_lang, src_filename):
 
     # Create a unique file name based on time
     current_time = str(datetime.datetime.now())
-    get_filename = current_time.replace(':', '_')
-    get_filename = get_filename.replace(' ', '_')
+    get_filename = current_time.replace(':', '_').replace(' ', '_')
 
-    # Download the Image File
-    r = requests.get(image_url, allow_redirects=True)
+    r = requests.get(image_url, allow_redirects=True, headers=getHeader())
     filename = get_filename + "." + r.headers.get('content-type').replace('image/', '')
     open("temp_images/" + filename, 'wb').write(r.content)
 
@@ -43,7 +42,7 @@ def process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses):
         "format": "json"
     }
 
-    response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses)
+    response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses, headers=getHeader())
     csrf_token = response.json()["query"]["tokens"]["csrftoken"]
 
     # API Parameter to upload the file
@@ -56,11 +55,8 @@ def process_upload(file_path, tr_filename, src_fileext, tr_endpoint, ses):
     }
 
     # Read the file for POST request
-    file = {
-        'file': open(file_path, 'rb')
-    }
-
-    response = requests.post(url=tr_endpoint, files=file, data=upload_param, auth=ses).json()
+    file = {'file': open(file_path, 'rb')}
+    response = requests.post(url=tr_endpoint, files=file, data=upload_param, auth=ses, headers=getHeader()).json()
 
     # Try block to get Link and URL
     try:
@@ -94,7 +90,7 @@ def get_localized_wikitext(wikitext, src_endpoint, target_lang):
                     }
 
                     try:
-                        response = requests.get(url=src_endpoint, params=lang_param)
+                        response = requests.get(url=src_endpoint, params=lang_param, headers=getHeader())
                         response.raise_for_status()
                         langlinks = response.json()["query"]["pages"][0]["langlinks"]
 
@@ -106,6 +102,93 @@ def get_localized_wikitext(wikitext, src_endpoint, target_lang):
                         return str(wikicode)
 
     return str(wikicode)
+
+def process_task_item(file_path, tr_project, task_item, src_fileext, ses):
+    """
+    Synchronously processes a single transfer tasks.
+    """
+    try:
+        lang = task_item.get("lang")
+        raw_tr_filename = task_item.get("trfilename", "")
+        tr_filename = urllib.parse.unquote(raw_tr_filename).strip()
+        
+        add_template = task_item.get("addTemplate", False)
+        page_content = task_item.get("pageContent", "")
+        edit_article = task_item.get("editArticle", False)
+        article_link = task_item.get("articleLink", "")
+        
+        if not lang or not tr_filename:
+            return None
+
+        tr_endpoint = f"https://{lang}.{tr_project}.org/w/api.php"
+
+        csrf_param = {
+            "action": "query",
+            "meta": "tokens",
+            "format": "json"
+        }
+        
+        response = requests.get(url=tr_endpoint, params=csrf_param, auth=ses, headers=getHeader())
+        response.raise_for_status()
+        csrf_token = response.json()["query"]["tokens"]["csrftoken"]
+        
+        upload_param = {
+            "action": "upload",
+            "filename": f"{tr_filename}.{src_fileext}",
+            "format": "json",
+            "token": csrf_token,
+            "ignorewarnings": 1
+        }
+
+        if add_template and page_content:
+            upload_param["text"] = page_content
+
+        with open(file_path, 'rb') as f:
+            files = {'file': f}
+            upload_resp = requests.post(
+                url=tr_endpoint, 
+                files=files, 
+                data=upload_param, 
+                auth=ses, 
+                headers=getHeader()
+            ).json()
+
+        if "error" in upload_resp:
+            return None
+
+        wikifile_url = upload_resp["upload"]["imageinfo"]["descriptionurl"]
+        file_link = upload_resp["upload"]["imageinfo"]["url"]
+
+        article_edit_success = None
+        if edit_article and article_link:
+            try:
+                image_title = f"{tr_filename}.{src_fileext}"
+                article_edit_success = edit_target_article(
+                    article_url=article_link, 
+                    tr_endpoint=tr_endpoint, 
+                    image_title=image_title, 
+                    csrf_token=csrf_token, 
+                    ses=ses
+                )
+            except Exception as e:
+                article_edit_success = False
+
+        return {
+            "wikipage_url": wikifile_url,
+            "file_link": file_link,
+            "article_edit_success": article_edit_success
+        }
+
+    except Exception as e:
+        return None
+
+def edit_target_article(article_url, tr_endpoint, image_title, csrf_token, ses):
+    """
+    Fetches the article wikitext, locates an empty image parameter in an template and inserts the uploaded image title.
+    """
+    # Implement later
+    raise NotImplementedError
+
 
 def getHeader():
     agent = 'Wikifile-transfer/1.0 (https://wikifile-transfer.toolforge.org; 0freerunning@gmail.com)'


### PR DESCRIPTION

#### Backend Changes
* **Multi-Language Upload API**: Added the `/api/upload_multi` endpoint to handle bulk upload requests. It processes uploads synchronously if there is only 1 target and the file is under 50MB; otherwise, it offloads them to Celery.
* **Granular Task Status (`app.py`)**: Updated the `/api/task_status/<task_id>` endpoint to return a `PARTIAL` status. This handles scenarios where the file uploads successfully but the subsequent target article edit fails.
* **Celery Task for Multi-Upload (`tasks.py`)**: Added `upload_task_item` to process individual asynchronous transfer requests. It includes logic for file upload, optional wikitext templates, and triggering the target article edit. 
* **Synchronous Fallback (`utils.py`)**: Added `process_task_item` as a lightweight synchronous alternative for simple file transfers.
* **Article Editing Stub**: Introduced the `edit_target_article` foundation in `utils.py` for locating and injecting the uploaded image into an empty image parameter in a target wiki article.
* **MediaWiki API Compliance**: Introduced `getHeader()` to append a custom `User-Agent` header (`Wikifile-transfer/1.0`) across all `requests` calls (CSRF fetching, localized wikitext fetching, uploading, etc.) to comply with Wikimedia API guidelines.

#### Frontend Changes
* **Multi-Language State Management**: Completely refactored `Upload.js` to manage an array of selected languages (capped at 3). Replaced scalar state variables with a `languageData` object to store independent target filenames, templates, and edit settings for each language.
* **Tab-Based UI**: Implemented `Tabs` across steps 2, 3, 4, and the final results screen to allow users to toggle between their selected languages and configure them individually.
* **Enhanced Polling Mechanism**: The frontend now polls multiple Celery tasks concurrently and groups the final results into a tabbed summary.
* **Granular Results Display**: The results screen now visually differentiates between `SUCCESS` (Green), `PARTIAL` (Warning), and `FAILURE` (Red) on a per-language basis.
* **New Configuration Steps**: 
  * **Step 3 (Add template)**: Users can optionally provide and append a wikitext description template during the file upload. 
  * **Step 4 (Edit article)**: Users can specify a target article link that they wish to have automatically updated with the newly uploaded image.
* **I18n Updates**: Added relevant localization strings in `en.json` to support the new features, validations, and status screens.

#### Cypress Testing Updated

### Tested:
1. Toast messages
2. APIs at each step
3. UI